### PR TITLE
release/v1.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ build/Release
 
 # Dependency directory
 node_modules
+yarn.lock
+npm-shrinkwrap.json
 
 # Optional npm cache directory
 .npm

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ client.authorizationCallback(..., ...).then(function (tokenSet) {
 
 ## Usage with passport
 Once you have a Client instance, just pass it to the Strategy. Issuer is best discovered, Client
-passed properties manually or via an uri (see [usage](#usage)).
+passed properties manually or via an uri (see [get-started](#get-started)).
 
 Verify function is invoked with a TokenSet, userinfo only when requested, last argument is always
 the done function which you invoke once you found your user.
@@ -370,7 +370,7 @@ passport.use('oidc', new Strategy(client, (tokenset, userinfo, done) => {
   });
 }));
 
-app.get('/auth', passport.authenticate('oidc', { /* authentication request params */ }));
+app.get('/auth', passport.authenticate('oidc'));
 app.get('/auth/cb', passport.authenticate('oidc', { successRedirect: '/', failureRedirect: '/login' }));
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Node.js
   - [Example](#example)
   - [Get started](#get-started)
   - [Usage](#usage)
+  - [Usage with passport](#usage-with-passport)
   - [Configuration](#configuration)
 
 <!-- TOC END -->
@@ -344,6 +345,33 @@ client.authorizationCallback(..., ...).then(function (tokenSet) {
   console.log('tokenSet#expired()', tokenSet.expired());
   console.log('tokenSet#claims', tokenSet.claims);
 });
+```
+
+## Usage with passport
+Once you have a Client instance, just pass it to the Strategy. Issuer is best discovered, Client
+passed properties manually or via an uri (see [usage](#usage)).
+
+Verify function is invoked with a TokenSet, userinfo only when requested, last argument is always
+the done function which you invoke once you found your user.
+
+```js
+const Strategy = require('openid-client').Strategy;
+
+passport.use('oidc', new Strategy(client, (tokenset, userinfo, done) => {
+  console.log('tokenset', tokenset);
+  console.log('access_token', tokenset.access_token);
+  console.log('id_token', tokenset.id_token);
+  console.log('claims', tokenset.claims);
+  console.log('userinfo', userinfo);
+
+  User.findOne({ id: tokenset.claims.sub }, function (err, user) {
+    if (err) return done(err);
+    return done(null, user);
+  });
+}));
+
+app.get('/auth', passport.authenticate('oidc', { /* authentication request params */ }));
+app.get('/auth/cb', passport.authenticate('oidc', { successRedirect: '/', failureRedirect: '/login' }));
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -356,8 +356,15 @@ the done function which you invoke once you found your user.
 
 ```js
 const Strategy = require('openid-client').Strategy;
+const params = {
+  // ... any authorization params
+  // client_id defaults to client.client_id
+  // redirect_uri defaults to redirect_uris[0]
+  // response type defaults to client.response_types[0], then 'code'
+  // scope defaults to 'openid'
+}
 
-passport.use('oidc', new Strategy(client, (tokenset, userinfo, done) => {
+passport.use('oidc', new Strategy({ client, [params] }, (tokenset, userinfo, done) => {
   console.log('tokenset', tokenset);
   console.log('access_token', tokenset.access_token);
   console.log('id_token', tokenset.id_token);
@@ -370,7 +377,11 @@ passport.use('oidc', new Strategy(client, (tokenset, userinfo, done) => {
   });
 }));
 
-app.get('/auth', passport.authenticate('oidc'));
+// start authentication request
+// options [optional], extra authentication parameters
+app.get('/auth', passport.authenticate('oidc', [options]));
+
+// authentication callback
 app.get('/auth/cb', passport.authenticate('oidc', { successRedirect: '/', failureRedirect: '/login' }));
 ```
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -218,7 +218,7 @@ class Client {
       uri = input;
     }
 
-    return url.parse(uri, true).query;
+    return _.pick(url.parse(uri, true).query, CALLBACK_PROPERTIES);
   }
 
   authorizationCallback(redirectUri, parameters, checks) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,8 +2,10 @@
 
 const Issuer = require('./issuer');
 const Registry = require('./issuer_registry');
+const Strategy = require('./passport_strategy');
 
 module.exports = {
   Issuer,
   Registry,
+  Strategy,
 };

--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -7,6 +7,25 @@ const assert = require('assert');
 const OpenIdConnectError = require('./open_id_connect_error');
 const Client = require('./client');
 
+const privates = new WeakMap();
+function instance(ctx) {
+  if (!privates.has(ctx)) privates.set(ctx, {});
+  return privates.get(ctx);
+}
+
+const MANDATORY = ['authorization_endpoint', 'jwks_uri', 'token_endpoint', 'userinfo_endpoint'];
+
+function verified(err, user, info) {
+  const add = info || {};
+  if (err) {
+    this.error(err);
+  } else if (!user) {
+    this.fail(add);
+  } else {
+    this.success(user, add);
+  }
+}
+
 class OpenIDConnectStrategy {
   constructor(options, verify) {
     const opts = (() => {
@@ -19,94 +38,99 @@ class OpenIDConnectStrategy {
     assert.equal(client instanceof Client, true);
     assert.equal(typeof verify, 'function');
 
-    assert(client.issuer.issuer);
-    assert(client.issuer.authorization_endpoint);
-    assert(client.issuer.jwks_uri);
-    assert(client.issuer.token_endpoint);
-    assert(client.issuer.userinfo_endpoint);
+    assert(client.issuer && client.issuer.issuer, 'client must have an issuer with an identifier');
+    MANDATORY.forEach((prop) => {
+      assert(client.issuer[prop], `client's issuer must have ${prop} configured`);
+    });
 
-    this.client = client;
-    this.issuer = client.issuer;
-    this.verify = verify;
+    instance(this).client = client;
+    instance(this).issuer = client.issuer;
+    instance(this).verify = verify;
+    const params = instance(this).params = opts.params || {};
+
     this.name = url.parse(client.issuer.issuer).hostname;
 
-    this.response_type = opts.response_type || _.get(client, 'response_types[0]', 'code');
-    this.redirect_uri = opts.redirect_uri || _.get(client, 'redirect_uris[0]');
-
-    this.scope = (() => {
-      if (Array.isArray(opts.scope)) {
-        return opts.scope.join(' ');
-      }
-      return opts.scope ? String(opts.scope) : 'openid';
-    })();
+    if (!params.response_type) params.response_type = _.get(client, 'response_types[0]', 'code');
+    if (!params.redirect_uri) params.redirect_uri = _.get(client, 'redirect_uris[0]');
+    if (!params.max_age && client.default_max_age) params.max_age = client.default_max_age;
+    if (!params.scope) params.scope = 'openid';
   }
 
-  authenticate(req) {
-    const params = this.client.callbackParams(req);
-    const sessionKey = `oidc:${url.parse(this.issuer.issuer).hostname}`;
-    const redirectUri = this.redirect_uri;
+  authenticate(req, options) {
+    const client = instance(this).client;
+    const issuer = instance(this).issuer;
+    try {
+      if (!req.session) throw new Error('authentication requires session support when using state, max_age or nonce');
+      const reqParams = client.callbackParams(req);
+      const sessionKey = `oidc:${url.parse(issuer.issuer).hostname}`;
 
-    if (_.isEmpty(params)) { // start authentication request
-      const opts = {
-        scope: this.scope,
-        response_type: this.response_type,
-        redirect_uri: redirectUri,
-        state: uuid(),
-        nonce: uuid(),
-      };
+      /* start authentication request */
+      if (_.isEmpty(reqParams)) {
+        // provide options.params for extra authentication parameters
+        const opts = _.chain(options).get('params', {}).defaults(instance(this).params, {
+          state: uuid(),
+        }).value();
 
-      req.session[sessionKey] = _.pick(opts, 'nonce', 'state');
-      this.redirect(this.client.authorizationUrl(opts));
-      return;
-    }
+        if (!opts.nonce && opts.response_type.includes('id_token')) {
+          opts.nonce = uuid();
+        }
 
-    const session = req.session[sessionKey] || {};
-    const state = session.state;
-    const nonce = session.nonce;
+        req.session[sessionKey] = _.pick(opts, 'nonce', 'state', 'max_age');
+        this.redirect(client.authorizationUrl(opts));
+        return;
+      }
+      /* end authentication request */
 
-    delete req.session[sessionKey];
+      /* start authentication response */
+      const session = _.get(req, `session.${sessionKey}`, {});
+      const state = session.state;
+      const maxAge = session.max_age;
+      const nonce = session.nonce;
 
-    let callback = this.client.authorizationCallback(redirectUri, params, { state, nonce })
-      .then((tokenset) => {
-        const result = { tokenset };
-        return result;
+      if (req.session) delete req.session[sessionKey];
+
+      const opts = _.defaults({}, options, {
+        redirect_uri: instance(this).params.redirect_uri,
       });
 
-    const loadUserinfo = this.verify.length > 2;
-    const verified = (err, user, info) => {
-      const add = info || {};
-      if (err) {
-        this.error(err);
-      } else if (!user) {
-        this.fail(add);
-      } else {
-        this.success(user, add);
-      }
-    };
-
-    if (loadUserinfo) {
-      callback = callback.then((result) => {
-        const userinfoRequest = this.client.userinfo(result.tokenset);
-        return userinfoRequest.then((userinfo) => {
-          result.userinfo = userinfo;
+      const checks = { state, nonce, max_age: maxAge };
+      let callback = client.authorizationCallback(opts.redirect_uri, reqParams, checks)
+        .then((tokenset) => {
+          const result = { tokenset };
           return result;
         });
-      });
-    }
 
-    callback.then((result) => {
-      if (result.userinfo) {
-        this.verify(result.tokenset, result.userinfo, verified);
-      } else {
-        this.verify(result.tokenset, verified);
+      const loadUserinfo = instance(this).verify.length > 2;
+
+      if (loadUserinfo) {
+        callback = callback.then((result) => {
+          const userinfoRequest = client.userinfo(result.tokenset);
+          return userinfoRequest.then((userinfo) => {
+            result.userinfo = userinfo;
+            return result;
+          });
+        });
       }
-    }).catch((error) => {
-      if (error instanceof OpenIdConnectError && error.error !== 'server_error') {
-        this.fail(error);
-      } else {
-        this.error(error);
-      }
-    });
+
+      callback.then((result) => {
+        if (result.userinfo) {
+          instance(this).verify(result.tokenset, result.userinfo, verified.bind(this));
+        } else {
+          instance(this).verify(result.tokenset, verified.bind(this));
+        }
+      }).catch((error) => {
+        if (error instanceof OpenIdConnectError &&
+              error.error !== 'server_error' &&
+              !error.error.startsWith('invalid')) {
+          this.fail(error);
+        } else {
+          this.error(error);
+        }
+      });
+      /* end authentication response */
+    } catch (err) {
+      this.error(err);
+    }
   }
 }
 

--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -52,7 +52,6 @@ class OpenIDConnectStrategy {
 
     if (!params.response_type) params.response_type = _.get(client, 'response_types[0]', 'code');
     if (!params.redirect_uri) params.redirect_uri = _.get(client, 'redirect_uris[0]');
-    if (!params.max_age && client.default_max_age) params.max_age = client.default_max_age;
     if (!params.scope) params.scope = 'openid';
   }
 
@@ -66,10 +65,10 @@ class OpenIDConnectStrategy {
 
       /* start authentication request */
       if (_.isEmpty(reqParams)) {
-        // provide options.params for extra authentication parameters
-        const opts = _.chain(options).get('params', {}).defaults(instance(this).params, {
+        // provide options objecti with extra authentication parameters
+        const opts = _.defaults({}, options, instance(this).params, {
           state: uuid(),
-        }).value();
+        });
 
         if (!opts.nonce && opts.response_type.includes('id_token')) {
           opts.nonce = uuid();

--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -50,6 +50,7 @@ class OpenIDConnectStrategy {
       const opts = {
         scope: this.scope,
         response_type: this.response_type,
+        redirect_uri: redirectUri,
         state: uuid(),
         nonce: uuid(),
       };

--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -60,7 +60,10 @@ class OpenIDConnectStrategy {
       return;
     }
 
-    const { nonce, state } = req.session[sessionKey] || {};
+    const session = req.session[sessionKey] || {};
+    const state = session.state;
+    const nonce = session.nonce;
+
     delete req.session[sessionKey];
 
     let callback = this.client.authorizationCallback(redirectUri, params, { state, nonce })
@@ -70,13 +73,14 @@ class OpenIDConnectStrategy {
       });
 
     const loadUserinfo = this.verify.length > 2;
-    const verified = (err, user, info = {}) => {
+    const verified = (err, user, info) => {
+      const add = info || {};
       if (err) {
         this.error(err);
       } else if (!user) {
-        this.fail(info);
+        this.fail(add);
       } else {
-        this.success(user, info);
+        this.success(user, add);
       }
     };
 

--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const _ = require('lodash');
+const uuid = require('uuid');
+const url = require('url');
+const assert = require('assert');
+const OpenIdConnectError = require('./open_id_connect_error');
+const Client = require('./client');
+
+class OpenIDConnectStrategy {
+  constructor(options, verify) {
+    const opts = (() => {
+      if (options instanceof Client) return { client: options };
+      return options;
+    })();
+
+    const client = opts.client;
+
+    assert.equal(client instanceof Client, true);
+    assert.equal(typeof verify, 'function');
+
+    assert(client.issuer.issuer);
+    assert(client.issuer.authorization_endpoint);
+    assert(client.issuer.jwks_uri);
+    assert(client.issuer.token_endpoint);
+    assert(client.issuer.userinfo_endpoint);
+
+    this.client = client;
+    this.issuer = client.issuer;
+    this.verify = verify;
+    this.name = url.parse(client.issuer.issuer).hostname;
+
+    this.response_type = opts.response_type || _.get(client, 'response_types[0]', 'code');
+    this.redirect_uri = opts.redirect_uri || _.get(client, 'redirect_uris[0]');
+
+    this.scope = (() => {
+      if (Array.isArray(opts.scope)) {
+        return opts.scope.join(' ');
+      }
+      return opts.scope ? String(opts.scope) : 'openid';
+    })();
+  }
+
+  authenticate(req) {
+    const params = this.client.callbackParams(req);
+    const sessionKey = `oidc:${url.parse(this.issuer.issuer).hostname}`;
+    const redirectUri = this.redirect_uri;
+
+    if (_.isEmpty(params)) { // start authentication request
+      const opts = {
+        scope: this.scope,
+        response_type: this.response_type,
+        state: uuid(),
+        nonce: uuid(),
+      };
+
+      req.session[sessionKey] = _.pick(opts, 'nonce', 'state');
+      this.redirect(this.client.authorizationUrl(opts));
+      return;
+    }
+
+    const { nonce, state } = req.session[sessionKey] || {};
+    delete req.session[sessionKey];
+
+    let callback = this.client.authorizationCallback(redirectUri, params, { state, nonce })
+      .then((tokenset) => {
+        const result = { tokenset };
+        return result;
+      });
+
+    const loadUserinfo = this.verify.length > 2;
+    const verified = (err, user, info = {}) => {
+      if (err) {
+        this.error(err);
+      } else if (!user) {
+        this.fail(info);
+      } else {
+        this.success(user, info);
+      }
+    };
+
+    if (loadUserinfo) {
+      callback = callback.then((result) => {
+        const userinfoRequest = this.client.userinfo(result.tokenset);
+        return userinfoRequest.then((userinfo) => {
+          result.userinfo = userinfo;
+          return result;
+        });
+      });
+    }
+
+    callback.then((result) => {
+      if (result.userinfo) {
+        this.verify(result.tokenset, result.userinfo, verified);
+      } else {
+        this.verify(result.tokenset, verified);
+      }
+    }).catch((error) => {
+      if (error instanceof OpenIdConnectError && error.error !== 'server_error') {
+        this.fail(error);
+      } else {
+        this.error(error);
+      }
+    });
+  }
+}
+
+module.exports = OpenIDConnectStrategy;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openid-client",
   "version": "1.4.0",
-  "description": "OpenID Connect Relying Party (RP, Client) implementation for Node.js",
+  "description": "OpenID Connect Relying Party (RP, Client) implementation for Node.js servers, supports passportjs",
   "main": "lib/index.js",
   "scripts": {
     "coverage": "make coverage",
@@ -25,6 +25,9 @@
     "authentication",
     "identity",
     "oauth",
+    "passport",
+    "passportjs",
+    "strategy",
     "certified",
     "dynamic",
     "config",

--- a/test/client/client_instance.test.js
+++ b/test/client/client_instance.test.js
@@ -1336,7 +1336,7 @@ describe('Client#validateIdToken', function () {
       aud: this.client.client_id,
       exp: now() + 3600,
       iat: now(),
-      auth_time: now() - 305,
+      auth_time: now() - 303,
     };
 
     return new this.IdToken(this.keystore.get(), 'RS256', payload)

--- a/test/strategy/strategy.test.js
+++ b/test/strategy/strategy.test.js
@@ -1,0 +1,271 @@
+'use strict';
+
+const http = require('http');
+const sinon = require('sinon');
+const MockRequest = require('readable-mock-req');
+const expect = require('chai').expect;
+const Issuer = require('../../lib').Issuer;
+const Strategy = require('../../lib').Strategy;
+
+describe('OpenIDConnectStrategy', function () {
+  before(function () {
+    this.origIncomingMessage = http.IncomingMessage;
+    http.IncomingMessage = MockRequest;
+  });
+
+  after(function () {
+    http.IncomingMessage = this.origIncomingMessage;
+  });
+
+  beforeEach(function () {
+    this.issuer = new Issuer({
+      issuer: 'https://op.example.com',
+      authorization_endpoint: 'https://op.example.com/auth',
+      jwks_uri: 'https://op.example.com/jwks',
+      token_endpoint: 'https://op.example.com/token',
+      userinfo_endpoint: 'https://op.example.com/userinfo',
+    });
+
+    this.client = new this.issuer.Client({
+      client_id: 'foo',
+      client_secret: 'barbaz',
+      respose_types: ['code'],
+      redirect_uris: ['http://rp.example.com/cb'],
+    });
+  });
+
+  describe('initate', function () {
+    it('gets some defaults from client', function () {
+      const strategy = new Strategy(this.client, () => {});
+      expect(strategy).to.have.property('scope', 'openid');
+      expect(strategy).to.have.property('response_type', 'code');
+      expect(strategy).to.have.property('redirect_uri', 'http://rp.example.com/cb');
+    });
+
+    it('can be passed those', function () {
+      const strategy = new Strategy({
+        client: this.client,
+        response_type: 'code id_token',
+        redirect_uri: 'http://rp.example.com/callback',
+        scope: ['openid', 'profile'],
+      }, () => {});
+      expect(strategy).to.have.property('scope', 'openid profile');
+      expect(strategy).to.have.property('response_type', 'code id_token');
+      expect(strategy).to.have.property('redirect_uri', 'http://rp.example.com/callback');
+    });
+
+    it('starts authentication requests for GETs', function () {
+      const strategy = new Strategy(this.client, () => {});
+
+      const req = new MockRequest('GET', '/login/oidc');
+      req.session = {};
+
+      strategy.redirect = sinon.spy();
+      strategy.authenticate(req);
+
+      expect(strategy.redirect.calledOnce).to.be.true;
+      const target = strategy.redirect.firstCall.args[0];
+      expect(target).to.include('redirect_uri=');
+      expect(target).to.include('scope=');
+      expect(target).to.include('nonce=');
+      expect(target).to.include('state=');
+      expect(req.session).to.have.property('oidc:op.example.com');
+      expect(req.session['oidc:op.example.com']).to.have.keys('nonce', 'state');
+    });
+
+    it('starts authentication requests for POSTs', function () {
+      const strategy = new Strategy(this.client, () => {});
+
+      const req = new MockRequest('POST', '/login/oidc');
+      req.session = {};
+      req.body = {};
+
+      strategy.redirect = sinon.spy();
+      strategy.authenticate(req);
+
+      expect(strategy.redirect.calledOnce).to.be.true;
+      const target = strategy.redirect.firstCall.args[0];
+      expect(target).to.include('redirect_uri=');
+      expect(target).to.include('scope=');
+      expect(target).to.include('nonce=');
+      expect(target).to.include('state=');
+      expect(req.session).to.have.property('oidc:op.example.com');
+      expect(req.session['oidc:op.example.com']).to.have.keys('nonce', 'state');
+    });
+  });
+
+  describe('callback', function () {
+    it('triggers the verify function and then the success one', function (next) {
+      const ts = { foo: 'bar' };
+      sinon.stub(this.client, 'authorizationCallback', function () {
+        return Promise.resolve(ts);
+      });
+
+      const strategy = new Strategy(this.client, (tokenset, done) => {
+        expect(tokenset).to.equal(ts);
+        done(null, tokenset);
+      });
+
+      strategy.success = () => { next(); };
+
+      const req = new MockRequest('GET', '/login/oidc/callback?code=foobar&state=state');
+      req.session = {
+        nonce: 'nonce',
+        state: 'state',
+      };
+
+      strategy.authenticate(req);
+    });
+
+    it('triggers the error function when server_error is encountered', function (next) {
+      const strategy = new Strategy(this.client, () => {});
+
+      const req = new MockRequest('GET', '/login/oidc/callback?error=server_error');
+      req.session = {
+        nonce: 'nonce',
+        state: 'state',
+      };
+
+      strategy.error = (error) => {
+        try {
+          expect(error.error).to.equal('server_error');
+          next();
+        } catch (err) {
+          next(err);
+        }
+      };
+
+      strategy.authenticate(req);
+    });
+
+    it('triggers the error function when non oidc error is encountered', function (next) {
+      const strategy = new Strategy(this.client, () => {});
+
+      sinon.stub(this.client, 'authorizationCallback', function () {
+        return Promise.reject(new Error('callback error'));
+      });
+
+      const req = new MockRequest('GET', '/login/oidc/callback?code=code');
+      req.session = {
+        nonce: 'nonce',
+        state: 'state',
+      };
+
+      strategy.error = (error) => {
+        try {
+          expect(error.message).to.equal('callback error');
+          next();
+        } catch (err) {
+          next(err);
+        }
+      };
+
+      strategy.authenticate(req);
+    });
+
+    it('triggers the fail function when oidc error is encountered', function (next) {
+      const strategy = new Strategy(this.client, () => {});
+
+      const req = new MockRequest('GET', '/login/oidc/callback?error=login_required');
+      req.session = {
+        nonce: 'nonce',
+        state: 'state',
+      };
+
+      strategy.fail = (error) => {
+        try {
+          expect(error.message).to.equal('login_required');
+          next();
+        } catch (err) {
+          next(err);
+        }
+      };
+
+      strategy.authenticate(req);
+    });
+
+    it('triggers the error function for errors during verify', function (next) {
+      const strategy = new Strategy(this.client, (tokenset, done) => {
+        done(new Error('user find error'));
+      });
+
+      const ts = { foo: 'bar' };
+      sinon.stub(this.client, 'authorizationCallback', function () {
+        return Promise.resolve(ts);
+      });
+
+      const req = new MockRequest('GET', '/login/oidc/callback?code=foo');
+      req.session = {
+        nonce: 'nonce',
+        state: 'state',
+      };
+
+      strategy.error = (error) => {
+        try {
+          expect(error.message).to.equal('user find error');
+          next();
+        } catch (err) {
+          next(err);
+        }
+      };
+
+      strategy.authenticate(req);
+    });
+
+    it('triggers the fail function when verify yields no account', function (next) {
+      const strategy = new Strategy(this.client, (tokenset, done) => {
+        done();
+      });
+
+      const ts = { foo: 'bar' };
+      sinon.stub(this.client, 'authorizationCallback', function () {
+        return Promise.resolve(ts);
+      });
+
+      const req = new MockRequest('GET', '/login/oidc/callback?code=foo');
+      req.session = {
+        nonce: 'nonce',
+        state: 'state',
+      };
+
+      strategy.fail = () => {
+        next();
+      };
+
+      strategy.authenticate(req);
+    });
+
+    it('does userinfo request too if part of verify arity', function (next) {
+      const strategy = new Strategy(this.client, (tokenset, userinfo, done) => {
+        try {
+          expect(tokenset).to.be.ok;
+          expect(userinfo).to.be.ok;
+          done(null, { sub: 'foobar' });
+        } catch (err) {
+          next(err);
+        }
+      });
+
+      const ts = { foo: 'bar' };
+      const ui = { sub: 'bar' };
+      sinon.stub(this.client, 'authorizationCallback', function () {
+        return Promise.resolve(ts);
+      });
+      sinon.stub(this.client, 'userinfo', function () {
+        return Promise.resolve(ui);
+      });
+
+      const req = new MockRequest('GET', '/login/oidc/callback?code=foo');
+      req.session = {
+        nonce: 'nonce',
+        state: 'state',
+      };
+
+      strategy.success = () => {
+        next();
+      };
+
+      strategy.authenticate(req);
+    });
+  });
+});


### PR DESCRIPTION
- added missing max_age, default_max_age related functionality
  - authorizationCallback now supports max_age check
  - clients with default_max_age use this default value automatically
  - when max_age is checked auth_time claim is mandatory and must be a number
- added missing require_auth_time related functionality
  - clients with require_auth_time = true have the presence and format of auth_time claim validated
- authorizationUrl and authorizationPost now removes null and undefined values and ensures parameters
  are stringified before passed to url.format
- added client.CLOCK_TOLERANCE property, to allow for clock skew (in seconds)
- added http://passportjs.org/ strategy