### PR TITLE
Don't assume that id_token response contains the authorization code

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -242,7 +242,7 @@ class Client {
     if (params.id_token) {
       promise = Promise.resolve(new TokenSet(params))
         .then(tokenset => this.decryptIdToken(tokenset, 'id_token'))
-        .then(tokenset => this.validateIdToken(tokenset, toCheck.nonce, 'id_token', toCheck.max_age));
+        .then(tokenset => this.validateIdToken(tokenset, toCheck.nonce, 'id_token', toCheck.max_age, params.code));
     }
 
     if (params.code) {
@@ -252,7 +252,7 @@ class Client {
         redirect_uri: redirectUri,
       })
         .then(tokenset => this.decryptIdToken(tokenset, 'id_token'))
-        .then(tokenset => this.validateIdToken(tokenset, toCheck.nonce, 'id_token', toCheck.max_age))
+        .then(tokenset => this.validateIdToken(tokenset, toCheck.nonce, 'id_token', toCheck.max_age, params.code))
         .then((tokenset) => {
           if (params.session_state) tokenset.session_state = params.session_state;
           return tokenset;
@@ -317,7 +317,7 @@ class Client {
       }));
   }
 
-  validateIdToken(token, nonce, intent, maxAge) {
+  validateIdToken(token, nonce, intent, maxAge, authorization_code) {
     let idToken = token;
 
     const use = (() => {
@@ -418,8 +418,8 @@ class Client {
       assert(tokenHash(payloadObject.at_hash, token.access_token), 'at_hash mismatch');
     }
 
-    if (isTokenSet && payloadObject.c_hash !== undefined) {
-      assert(tokenHash(payloadObject.c_hash, token.code), 'c_hash mismatch');
+    if (isTokenSet && payloadObject.c_hash !== undefined && authorization_code !== undefined) {
+      assert(tokenHash(payloadObject.c_hash, authorization_code), 'c_hash mismatch');
     }
 
     if (headerObject.alg === 'none') {
@@ -452,7 +452,7 @@ class Client {
         return tokenset;
       }
       return this.decryptIdToken(tokenset, 'id_token')
-        .then(() => this.validateIdToken(tokenset, null, 'id_token', null));
+        .then(() => this.validateIdToken(tokenset, null, 'id_token', null, null));
     });
   }
 
@@ -494,7 +494,7 @@ class Client {
             .then(jwt => this.decryptIdToken(jwt, 'userinfo'))
             .then((jwt) => {
               if (!this.userinfo_signed_response_alg) return JSON.parse(jwt);
-              return this.validateIdToken(jwt, null, 'userinfo', null)
+              return this.validateIdToken(jwt, null, 'userinfo', null, null)
                 .then(valid => JSON.parse(base64url.decode(valid.split('.')[1])));
             });
         }

--- a/test/client/client_instance.test.js
+++ b/test/client/client_instance.test.js
@@ -1467,8 +1467,8 @@ describe('Client#validateIdToken', function () {
       iat: now(),
     })
     .then((token) => {
-      const tokenset = new TokenSet({ code, id_token: token });
-      return this.client.validateIdToken(tokenset);
+      const tokenset = new TokenSet({ id_token: token });
+      return this.client.validateIdToken(tokenset, null, null, null, code);
     });
   });
 
@@ -1485,8 +1485,8 @@ describe('Client#validateIdToken', function () {
       iat: now(),
     })
     .then((token) => {
-      const tokenset = new TokenSet({ code, id_token: token });
-      return this.client.validateIdToken(tokenset);
+      const tokenset = new TokenSet({ id_token: token });
+      return this.client.validateIdToken(tokenset, null, null, null, code);
     })
     .then(fail, (error) => {
       expect(error).to.have.property('message', 'c_hash mismatch');


### PR DESCRIPTION
I was getting the following error after receiving the ID token from an
instance of the Ipsilon identity server.

    AssertionError: 'undefined' == 'string',
    {"name":"AssertionError","actual":"undefined","expected":"string","operator":"==","message":"'undefined'
    == 'string'","generatedMessage":true}

The issue is in verifying the 'c_hash' field of the response. The code
tried to check it against the 'code' field of the id_token, but this
isn't included in the response from Ipsilon.

I can't find anything in the OpenID Connect Core standard that requires
the authorization code to be included in the ID token response, so it
looks like the client library needs to be fixed to not require that.