### PR TITLE
prevent revoke unexpected eof error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -587,7 +587,8 @@ class Client {
 
     const body = { token };
     if (hint) body.token_type_hint = hint;
-    return this.authenticatedPost('revocation', { body }, response => JSON.parse(response.body));
+    return this.authenticatedPost('revocation', { body },
+      response => response.body ? JSON.parse(response.body) : response);
   }
 
   /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -587,8 +587,12 @@ class Client {
 
     const body = { token };
     if (hint) body.token_type_hint = hint;
-    return this.authenticatedPost('revocation', { body },
-      response => response.body ? JSON.parse(response.body) : response);
+    return this.authenticatedPost('revocation', { body }, (response) => {
+      if (response.body) {
+        return JSON.parse(response.body);
+      }
+      return {};
+    });
   }
 
   /**

--- a/test/client/client_instance.test.js
+++ b/test/client/client_instance.test.js
@@ -736,6 +736,23 @@ describe('Client', function () {
             expect(error).to.have.property('message').matches(/Unexpected token/);
           });
       });
+
+      if (method === 'revoke') {
+        it('handles empty bodies', function () {
+          nock('https://rp.example.com')
+            .post(`/token/${method}`)
+            .reply(200);
+
+          const issuer = new Issuer({
+            [metas[0]]: `https://rp.example.com/token/${method}`,
+          });
+          const client = new issuer.Client();
+
+          return client[method]('tokenValue').then((response) => {
+            expect(response).to.eql({});
+          });
+        });
+      }
     });
   });
 


### PR DESCRIPTION
Typically a revocation call does not have a response body and the current `successHandler` attempts to parse the response body and return it, resulting in `unexpected end of json input` error.

Fix that negates parsing the body if it’s not present.