### PR TITLE
Change Issuer Assert to OK.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -379,7 +379,7 @@ class Client {
     }
 
     if (payload.iss !== undefined) {
-      assert.equal(this.issuer.issuer, payload.iss, 'unexpected iss value');
+      assert.ok(this.issuer.issuer.startsWith(payload.iss), 'unexpected iss value');
     }
 
     if (payload.iat !== undefined) {


### PR DESCRIPTION
When I set the `defaultHttpOptions` to use a port like so:

```
Issuer.defaultHttpOptions = { 
			port: 443,
			agent: tunnel.httpsOverHttp({
				proxy: {
					host: 'myproxy',
					port: 8080
				}
			})
		};
```

The `assert` fails since the `issuer` now has a `:443` tacked on. There might be more elegant ways of doing this but all I could come up with was to use a `startsWith` instead of using the `equal`.