### PR TITLE
Allow session key to be specified in passport strategy options

### DIFF
--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -38,7 +38,7 @@ function OpenIDConnectStrategy(options, verify) {
   assert(client.issuer && client.issuer.issuer, 'client must have an issuer with an identifier');
 
   this._client = client;
-  this._issuer = client.issuer;  
+  this._issuer = client.issuer;
   this._verify = verify;
   this._key = opts.sessionKey || `oidc:${url.parse(this._issuer.issuer).hostname}`;
   this._params = opts.params || {};

--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -38,8 +38,9 @@ function OpenIDConnectStrategy(options, verify) {
   assert(client.issuer && client.issuer.issuer, 'client must have an issuer with an identifier');
 
   this._client = client;
-  this._issuer = client.issuer;
+  this._issuer = client.issuer;  
   this._verify = verify;
+  this._key = opts.sessionKey || `oidc:${url.parse(this._issuer.issuer).hostname}`;
   this._params = opts.params || {};
   const params = this._params;
 
@@ -56,7 +57,7 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
   try {
     if (!req.session) throw new Error('authentication requires session support when using state, max_age or nonce');
     const reqParams = client.callbackParams(req);
-    const sessionKey = `oidc:${url.parse(issuer.issuer).hostname}`;
+    const sessionKey = this._key;
 
     /* start authentication request */
     if (_.isEmpty(reqParams)) {

--- a/test/passport/passport_strategy.test.js
+++ b/test/passport/passport_strategy.test.js
@@ -132,6 +132,22 @@ describe('OpenIDConnectStrategy', function () {
       expect(req.session).to.have.property('oidc:op.example.com');
       expect(req.session['oidc:op.example.com']).to.have.keys('state', 'nonce');
     });
+
+    it('can have session key specifed', function () {
+      const strategy = new Strategy({
+        client: this.client,
+        sessionKey: 'oidc:op.example.com:foo'
+      }, () => {});
+
+      const req = new MockRequest('GET', '/login/oidc');
+      req.session = {};
+
+      strategy.redirect = sinon.spy();
+      strategy.authenticate(req);
+
+      expect(req.session).to.have.property('oidc:op.example.com:foo');
+      expect(req.session['oidc:op.example.com:foo']).to.have.keys('state');
+    });
   });
 
   describe('callback', function () {


### PR DESCRIPTION
PR to address the issue I opened earlier. Added 1 new test and all others continue to pass. Thank you and let me know if I missed anything.