### PR TITLE
Add TokenSet support for refresh_expires_in and refresh_expires_at

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ package-lock.json
 
 # Optional REPL history
 .node_repl_history
+
+# IDEs and editors
+.idea

--- a/lib/token_set.js
+++ b/lib/token_set.js
@@ -39,6 +39,30 @@ class TokenSet {
   }
 
   /**
+   * @name refresh_expires_in=
+   * @api public
+   */
+  set refresh_expires_in(value) { // eslint-disable-line camelcase
+    this.refresh_expires_at = now() + Number(value);
+  }
+
+  /**
+   * @name refresh_expires_in
+   * @api public
+   */
+  get refresh_expires_in() { // eslint-disable-line camelcase
+    return Math.max.apply(null, [this.refresh_expires_at - now(), 0]);
+  }
+
+  /**
+   * @name refresh_expired
+   * @api public
+   */
+  refresh_expired() { // eslint-disable-line camelcase
+    return this.refresh_expires_in === 0;
+  }
+
+  /**
    * @name claims
    * @api public
    */

--- a/test/tokenset/tokenset.test.js
+++ b/test/tokenset/tokenset.test.js
@@ -21,7 +21,7 @@ describe('TokenSet', function () {
     expect(ts.expired()).to.be.false;
   });
 
-  it('expired token sets', function () {
+  it('expired token sets expires_in to 0', function () {
     const ts = new TokenSet({
       expires_in: -30,
     });
@@ -29,6 +29,26 @@ describe('TokenSet', function () {
     expect(ts).to.have.property('expires_at', now() - 30);
     expect(ts).to.have.property('expires_in', 0);
     expect(ts.expired()).to.be.true;
+  });
+
+  it('sets the refresh_expire_at automatically from refresh_expires_in', function () {
+    const ts = new TokenSet({
+      refresh_expires_in: 300,
+    });
+
+    expect(ts).to.have.property('refresh_expires_at', now() + 300);
+    expect(ts).to.have.property('refresh_expires_in', 300);
+    expect(ts.refresh_expired()).to.be.false;
+  });
+
+  it('expired refresh_token sets refresh_expires_in to 0', function () {
+    const ts = new TokenSet({
+      refresh_expires_in: -30,
+    });
+
+    expect(ts).to.have.property('refresh_expires_at', now() - 30);
+    expect(ts).to.have.property('refresh_expires_in', 0);
+    expect(ts.refresh_expired()).to.be.true;
   });
 
   it('provides a #claims getter', function () {


### PR DESCRIPTION
Added support for the non standard token property `refresh_expires_in` (based on similar support for `expires_in`)

Some OAuth2 providers add a `refresh_expires_in` attribute to the token (see [Keycloak](https://issues.jboss.org/browse/KEYCLOAK-760)). 
It behaves the same way `expires_in` does, but it is applied to the `refresh_token`