### PR TITLE
Fix error reporting in issuer field

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -461,7 +461,7 @@ class Client {
     }
 
     if (payload.iss !== undefined) {
-      assert.equal(this.issuer.issuer, payload.iss, 'unexpected iss value');
+      assert.equal(payload.iss, this.issuer.issuer, 'unexpected iss value');
     }
 
     if (payload.iat !== undefined) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -501,7 +501,7 @@ class Client {
     }
 
     if (payload.azp !== undefined) {
-      assert.equal(this.client_id, payload.azp, 'azp must be the client_id');
+      assert.equal(payload.azp, this.client_id, 'azp must be the client_id');
     }
 
     if (payload.aud !== undefined) {
@@ -624,7 +624,7 @@ class Client {
       })
       .then((parsed) => {
         if (accessToken.id_token) {
-          assert.equal(getSub(accessToken.id_token), parsed.sub, 'userinfo sub mismatch');
+          assert.equal(parsed.sub, getSub(accessToken.id_token), 'userinfo sub mismatch');
         }
 
         return parsed;

--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -34,7 +34,7 @@ function OpenIDConnectStrategy(options, verify) {
 
   const client = opts.client;
 
-  assert(client instanceof Client);
+  assert(client instanceof Client, 'client must be an instance of openid-client Client');
   assert.equal(typeof verify, 'function', 'verify must be a function');
 
   assert(client.issuer && client.issuer.issuer, 'client must have an issuer with an identifier');

--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -34,8 +34,8 @@ function OpenIDConnectStrategy(options, verify) {
 
   const client = opts.client;
 
-  assert.equal(client instanceof Client, true);
-  assert.equal(typeof verify, 'function');
+  assert(client instanceof Client);
+  assert.equal(typeof verify, 'function', 'verify must be a function');
 
   assert(client.issuer && client.issuer.issuer, 'client must have an issuer with an identifier');
 


### PR DESCRIPTION
We were expecting the wrong value in the issuer field and debugging was a little hard because the error message had the expected and actual values the wrong way around. This should swap them back.