### PR TITLE
proxy settings / use request instead of got

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,45 @@ Confirm your httpOptions by
 console.log('httpOptions %j', Issuer.defaultHttpOptions);
 ```
 
+### Proxy settings
+Because of the lightweight nature of [got][got-library] library the client will not use
+environment-defined http(s) proxies. In order to have them used you'll need to either provide your own http request
+implementation using the provided `httpClient` setter or use the bundled [request][request-library]
+one.
+
+Custom implementation:
+```js
+/*
+ * url {String}
+ * options {Object}
+ * options.headers {Object}
+ * options.body {String|Object}
+ * options.form {Boolean}
+ * options.query {Object}
+ * options.timeout {Number}
+ * options.retries {Number}
+ * options.followRedirect {Boolean}
+ */
+
+Issuer.httpClient = {
+   get(url, options) {}, // return Promise
+   post(url, options) {}, // return Promise
+   HTTPError, // used error constructor
+};
+```
+
+Bundled (and maintained + tested) request implementation after you've added [request][request-library]
+to your package.json bundle:
+
+```
+npm install request@^2.0.0 --save
+```
+
+```js
+Issuer.useRequest();
+```
+
+
 [travis-image]: https://img.shields.io/travis/panva/node-openid-client/master.svg?style=flat-square&maxAge=7200
 [travis-url]: https://travis-ci.org/panva/node-openid-client
 [conformance-image]: https://img.shields.io/travis/panva/openid-client-conformance-tests/master.svg?style=flat-square&maxAge=7200&label=conformance%20build
@@ -450,6 +489,7 @@ console.log('httpOptions %j', Issuer.defaultHttpOptions);
 [feature-revocation]: https://tools.ietf.org/html/rfc7009
 [feature-introspection]: https://tools.ietf.org/html/rfc7662
 [got-library]: https://github.com/sindresorhus/got
+[request-library]: https://github.com/request/request
 [signed-userinfo]: http://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse
 [openid-certified-link]: http://openid.net/certification/
 [openid-certified-logo]: https://cdn.rawgit.com/panva/node-openid-client/master/OpenID_Certified.png

--- a/lib/http.js
+++ b/lib/http.js
@@ -5,6 +5,7 @@ const got = require('got');
  * options {Object}
  * options.headers {Object}
  * options.body {String|Object}
+ * options.form {Boolean}
  * options.query {Object}
  * options.timeout {Number}
  * options.retries {Number}

--- a/lib/http_request.js
+++ b/lib/http_request.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const http = require('http');
+
+/*
+ * url {String}
+ * options {Object}
+ * options.headers {Object}
+ * options.body {String|Object}
+ * options.form {Boolean}
+ * options.query {Object}
+ * options.timeout {Number}
+ * options.retries {Number}
+ * options.followRedirect {Boolean}
+ */
+
+class HTTPError extends Error {
+  constructor(response) {
+    const statusMessage = http.STATUS_CODES[response.statusCode];
+    super(`Response code ${response.statusCode} (${statusMessage})`, {});
+    this.name = 'HTTPError';
+    this.statusCode = response.statusCode;
+    this.statusMessage = statusMessage;
+    this.headers = response.headers;
+    this.response = response;
+  }
+}
+
+module.exports = function requestWrapper() {
+  const request = require('request'); // eslint-disable-line import/no-extraneous-dependencies, global-require
+
+  function requestWrap(method, url, options) {
+    if (options.form) {
+      options.form = options.body;
+      options.body = undefined;
+    }
+    return new Promise((resolve, reject) => {
+      request({
+        method,
+        url,
+        headers: options.headers,
+        qs: options.query,
+        body: options.body,
+        form: options.form,
+        followRedirect: options.followRedirect,
+        timeout: options.timeout,
+      }, (error, response, body) => {
+        if (error) {
+          reject(error);
+        } else {
+          response.body = body;
+          const statusCode = response.statusCode;
+          const limitStatusCode = options.followRedirect ? 299 : 399;
+
+          if (statusCode !== 304 && (statusCode < 200 || statusCode > limitStatusCode)) {
+            reject(new HTTPError(response));
+            return;
+          }
+
+          resolve(response);
+        }
+      });
+    });
+  }
+
+  return {
+    HTTPError,
+    get(url, options) {
+      return requestWrap('GET', url, options);
+    },
+    post(url, options) {
+      return requestWrap('POST', url, options);
+    },
+  };
+};

--- a/lib/issuer.js
+++ b/lib/issuer.js
@@ -7,6 +7,7 @@ const url = require('url');
 const _ = require('lodash');
 const LRU = require('lru-cache');
 const http = require('./http');
+const httpRequest = require('./http_request');
 
 const DEFAULT_HTTP_OPTIONS = require('./consts').DEFAULT_HTTP_OPTIONS;
 const ISSUER_DEFAULTS = require('./consts').ISSUER_DEFAULTS;
@@ -194,6 +195,14 @@ class Issuer {
       .catch(errorHandler.bind(this));
   }
 
+  static useGot() {
+    this.httpClient = http;
+  }
+
+  static useRequest() {
+    this.httpClient = httpRequest();
+  }
+
   get httpClient() {
     return this.constructor.httpClient;
   }
@@ -242,6 +251,6 @@ class Issuer {
   }
 }
 
-Issuer.httpClient = http;
+Issuer.useGot();
 
 module.exports = Issuer;

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "nyc": "^11.0.1",
     "pre-commit": "^1.2.2",
     "readable-mock-req": "^0.2.2",
+    "request": "^2.83.0",
     "sinon": "^4.0.0",
     "timekeeper": "^2.0.0"
   },

--- a/test/client/client_instance.test.js
+++ b/test/client/client_instance.test.js
@@ -22,2268 +22,992 @@ const noop = () => {};
 const fail = () => { throw new Error('expected promise to be rejected'); };
 const encode = object => base64url.encode(JSON.stringify(object));
 
-describe('Client', function () {
-  afterEach(timekeeper.reset);
-  afterEach(nock.cleanAll);
-
-  describe('#authorizationUrl', function () {
+['useGot', 'useRequest'].forEach((httpProvider) => {
+  describe(`Client - using ${httpProvider.substring(3).toLowerCase()}`, function () {
     before(function () {
-      const issuer = new Issuer({
-        authorization_endpoint: 'https://op.example.com/auth',
+      Issuer[httpProvider]();
+    });
+
+    afterEach(timekeeper.reset);
+    afterEach(nock.cleanAll);
+
+    describe('#authorizationUrl', function () {
+      before(function () {
+        const issuer = new Issuer({
+          authorization_endpoint: 'https://op.example.com/auth',
+        });
+        this.client = new issuer.Client({
+          client_id: 'identifier',
+        });
       });
-      this.client = new issuer.Client({
-        client_id: 'identifier',
+
+      it('returns a string with the url with some basic defaults', function () {
+        expect(url.parse(this.client.authorizationUrl({
+          redirect_uri: 'https://rp.example.com/cb',
+        }), true).query).to.eql({
+          client_id: 'identifier',
+          redirect_uri: 'https://rp.example.com/cb',
+          response_type: 'code',
+          scope: 'openid',
+        });
+      });
+
+      it('allows to overwrite the defaults', function () {
+        expect(url.parse(this.client.authorizationUrl({
+          scope: 'openid offline_access',
+          redirect_uri: 'https://rp.example.com/cb',
+          response_type: 'id_token',
+          nonce: 'foobar',
+        }), true).query).to.eql({
+          client_id: 'identifier',
+          scope: 'openid offline_access',
+          redirect_uri: 'https://rp.example.com/cb',
+          response_type: 'id_token',
+          nonce: 'foobar',
+        });
+      });
+
+      it('allows any other params to be provide too', function () {
+        expect(url.parse(this.client.authorizationUrl({
+          state: 'state',
+          custom: 'property',
+        }), true).query).to.contain({
+          state: 'state',
+          custom: 'property',
+        });
+      });
+
+      it('auto-stringifies claims parameter', function () {
+        expect(url.parse(this.client.authorizationUrl({
+          claims: { id_token: { email: null } },
+        }), true).query).to.contain({
+          claims: '{"id_token":{"email":null}}',
+        });
+      });
+
+      it('removes null and undefined values', function () {
+        expect(url.parse(this.client.authorizationUrl({
+          state: null,
+          prompt: undefined,
+        }), true).query).not.to.have.keys('state', 'prompt');
+      });
+
+      it('stringifies other values', function () {
+        expect(url.parse(this.client.authorizationUrl({
+          max_age: 300,
+          foo: true,
+        }), true).query).to.contain({
+          max_age: '300',
+          foo: 'true',
+        });
       });
     });
 
-    it('returns a string with the url with some basic defaults', function () {
-      expect(url.parse(this.client.authorizationUrl({
-        redirect_uri: 'https://rp.example.com/cb',
-      }), true).query).to.eql({
-        client_id: 'identifier',
-        redirect_uri: 'https://rp.example.com/cb',
-        response_type: 'code',
-        scope: 'openid',
+    describe('#authorizationPost', function () {
+      const REGEXP = /name="(.+)" value="(.+)"/g;
+
+      function paramsFromHTML(html) {
+        const params = {};
+
+        const matches = html.match(REGEXP);
+        matches.forEach((line) => {
+          line.match(REGEXP);
+          params[RegExp.$1] = RegExp.$2;
+        });
+
+        return params;
+      }
+
+      before(function () {
+        const issuer = new Issuer({
+          authorization_endpoint: 'https://op.example.com/auth',
+        });
+        this.client = new issuer.Client({
+          client_id: 'identifier',
+        });
+      });
+
+      it('returns a string with the url with some basic defaults', function () {
+        expect(paramsFromHTML(this.client.authorizationPost({
+          redirect_uri: 'https://rp.example.com/cb',
+        }))).to.eql({
+          client_id: 'identifier',
+          redirect_uri: 'https://rp.example.com/cb',
+          response_type: 'code',
+          scope: 'openid',
+        });
+      });
+
+      it('allows to overwrite the defaults', function () {
+        expect(paramsFromHTML(this.client.authorizationPost({
+          scope: 'openid offline_access',
+          redirect_uri: 'https://rp.example.com/cb',
+          response_type: 'id_token',
+          nonce: 'foobar',
+        }))).to.eql({
+          client_id: 'identifier',
+          scope: 'openid offline_access',
+          redirect_uri: 'https://rp.example.com/cb',
+          response_type: 'id_token',
+          nonce: 'foobar',
+        });
+      });
+
+      it('allows any other params to be provide too', function () {
+        expect(paramsFromHTML(this.client.authorizationPost({
+          state: 'state',
+          custom: 'property',
+        }))).to.contain({
+          state: 'state',
+          custom: 'property',
+        });
+      });
+
+      it('auto-stringifies claims parameter', function () {
+        expect(paramsFromHTML(this.client.authorizationPost({
+          claims: { id_token: { email: null } },
+        }))).to.contain({
+          claims: '{"id_token":{"email":null}}',
+        });
       });
     });
 
-    it('allows to overwrite the defaults', function () {
-      expect(url.parse(this.client.authorizationUrl({
-        scope: 'openid offline_access',
-        redirect_uri: 'https://rp.example.com/cb',
-        response_type: 'id_token',
-        nonce: 'foobar',
-      }), true).query).to.eql({
-        client_id: 'identifier',
-        scope: 'openid offline_access',
-        redirect_uri: 'https://rp.example.com/cb',
-        response_type: 'id_token',
-        nonce: 'foobar',
-      });
-    });
-
-    it('allows any other params to be provide too', function () {
-      expect(url.parse(this.client.authorizationUrl({
-        state: 'state',
-        custom: 'property',
-      }), true).query).to.contain({
-        state: 'state',
-        custom: 'property',
-      });
-    });
-
-    it('auto-stringifies claims parameter', function () {
-      expect(url.parse(this.client.authorizationUrl({
-        claims: { id_token: { email: null } },
-      }), true).query).to.contain({
-        claims: '{"id_token":{"email":null}}',
-      });
-    });
-
-    it('removes null and undefined values', function () {
-      expect(url.parse(this.client.authorizationUrl({
-        state: null,
-        prompt: undefined,
-      }), true).query).not.to.have.keys('state', 'prompt');
-    });
-
-    it('stringifies other values', function () {
-      expect(url.parse(this.client.authorizationUrl({
-        max_age: 300,
-        foo: true,
-      }), true).query).to.contain({
-        max_age: '300',
-        foo: 'true',
-      });
-    });
-  });
-
-  describe('#authorizationPost', function () {
-    const REGEXP = /name="(.+)" value="(.+)"/g;
-
-    function paramsFromHTML(html) {
-      const params = {};
-
-      const matches = html.match(REGEXP);
-      matches.forEach((line) => {
-        line.match(REGEXP);
-        params[RegExp.$1] = RegExp.$2;
+    describe('#authorizationCallback', function () {
+      before(function () {
+        this.issuer = new Issuer({
+          token_endpoint: 'https://op.example.com/token',
+        });
+        this.client = new this.issuer.Client({
+          client_id: 'identifier',
+          client_secret: 'secure',
+        });
       });
 
-      return params;
-    }
+      it('does an authorization_code grant with code and redirect_uri', function () {
+        nock('https://op.example.com')
+          .filteringRequestBody(function (body) {
+            expect(querystring.parse(body)).to.eql({
+              code: 'codeValue',
+              redirect_uri: 'https://rp.example.com/cb',
+              grant_type: 'authorization_code',
+            });
+          })
+          .post('/token')
+          .reply(200, {});
 
-    before(function () {
-      const issuer = new Issuer({
-        authorization_endpoint: 'https://op.example.com/auth',
-      });
-      this.client = new issuer.Client({
-        client_id: 'identifier',
-      });
-    });
-
-    it('returns a string with the url with some basic defaults', function () {
-      expect(paramsFromHTML(this.client.authorizationPost({
-        redirect_uri: 'https://rp.example.com/cb',
-      }))).to.eql({
-        client_id: 'identifier',
-        redirect_uri: 'https://rp.example.com/cb',
-        response_type: 'code',
-        scope: 'openid',
-      });
-    });
-
-    it('allows to overwrite the defaults', function () {
-      expect(paramsFromHTML(this.client.authorizationPost({
-        scope: 'openid offline_access',
-        redirect_uri: 'https://rp.example.com/cb',
-        response_type: 'id_token',
-        nonce: 'foobar',
-      }))).to.eql({
-        client_id: 'identifier',
-        scope: 'openid offline_access',
-        redirect_uri: 'https://rp.example.com/cb',
-        response_type: 'id_token',
-        nonce: 'foobar',
-      });
-    });
-
-    it('allows any other params to be provide too', function () {
-      expect(paramsFromHTML(this.client.authorizationPost({
-        state: 'state',
-        custom: 'property',
-      }))).to.contain({
-        state: 'state',
-        custom: 'property',
-      });
-    });
-
-    it('auto-stringifies claims parameter', function () {
-      expect(paramsFromHTML(this.client.authorizationPost({
-        claims: { id_token: { email: null } },
-      }))).to.contain({
-        claims: '{"id_token":{"email":null}}',
-      });
-    });
-  });
-
-  describe('#authorizationCallback', function () {
-    before(function () {
-      this.issuer = new Issuer({
-        token_endpoint: 'https://op.example.com/token',
-      });
-      this.client = new this.issuer.Client({
-        client_id: 'identifier',
-        client_secret: 'secure',
-      });
-    });
-
-    it('does an authorization_code grant with code and redirect_uri', function () {
-      nock('https://op.example.com')
-        .filteringRequestBody(function (body) {
-          expect(querystring.parse(body)).to.eql({
-            code: 'codeValue',
-            redirect_uri: 'https://rp.example.com/cb',
-            grant_type: 'authorization_code',
-          });
+        return this.client.authorizationCallback('https://rp.example.com/cb', {
+          code: 'codeValue',
         })
-        .post('/token')
-        .reply(200, {});
+          .then(fail, () => {
+            expect(nock.isDone()).to.be.true;
+          });
+      });
 
-      return this.client.authorizationCallback('https://rp.example.com/cb', {
-        code: 'codeValue',
-      })
-        .then(fail, () => {
+      it('pushes default_max_age to #validateIdToken', function () {
+        const client = new this.issuer.Client({
+          client_id: 'with-default_max_age',
+          client_secret: 'secure',
+          default_max_age: 300,
+        });
+
+        nock('https://op.example.com')
+          .post('/token')
+          .reply(200, {
+            id_token: 'foobar',
+          });
+
+        sinon.spy(client, 'validateIdToken');
+
+        return client.authorizationCallback('https://rp.example.com/cb', {
+          code: 'codeValue',
+        })
+          .then(fail, () => {
+            expect(client.validateIdToken.calledOnce).to.be.true;
+            expect(client.validateIdToken.firstCall.args[3]).to.equal(300);
+          });
+      });
+
+      it('rejects with OpenIdConnectError when part of the response', function () {
+        return this.client.authorizationCallback('https://rp.example.com/cb', {
+          error: 'invalid_request',
+        }).then(fail, (error) => {
+          expect(error).to.be.instanceof(OpenIdConnectError);
+          expect(error).to.have.property('message', 'invalid_request');
+        });
+      });
+
+      it('rejects with an Error when states mismatch (returned)', function () {
+        return this.client.authorizationCallback('https://rp.example.com/cb', {
+          state: 'should be checked for this',
+        }).then(fail, (error) => {
+          expect(error).to.be.instanceof(Error);
+          expect(error).to.have.property('message', 'state mismatch');
+        });
+      });
+
+      it('rejects with an Error when states mismatch (not returned)', function () {
+        return this.client.authorizationCallback('https://rp.example.com/cb', {}, {
+          state: 'should be this',
+        })
+          .then(fail, (error) => {
+            expect(error).to.be.instanceof(Error);
+            expect(error).to.have.property('message', 'state mismatch');
+          });
+      });
+
+      it('rejects with an Error when states mismatch (general mismatch)', function () {
+        return this.client.authorizationCallback('https://rp.example.com/cb', {
+          state: 'is this',
+        }, {
+          state: 'should be this',
+        })
+          .then(fail, (error) => {
+            expect(error).to.be.instanceof(Error);
+            expect(error).to.have.property('message', 'state mismatch');
+          });
+      });
+    });
+
+    describe('#oauthCallback', function () {
+      before(function () {
+        this.issuer = new Issuer({
+          token_endpoint: 'https://op.example.com/token',
+        });
+        this.client = new this.issuer.Client({
+          client_id: 'identifier',
+          client_secret: 'secure',
+        });
+      });
+
+      it('does an authorization_code grant with code and redirect_uri', function () {
+        nock('https://op.example.com')
+          .filteringRequestBody(function (body) {
+            expect(querystring.parse(body)).to.eql({
+              code: 'codeValue',
+              redirect_uri: 'https://rp.example.com/cb',
+              grant_type: 'authorization_code',
+            });
+          })
+          .post('/token')
+          .reply(200, {
+            access_token: 'tokenValue',
+          });
+
+        return this.client.oauthCallback('https://rp.example.com/cb', {
+          code: 'codeValue',
+        }).then((set) => {
           expect(nock.isDone()).to.be.true;
-        });
-    });
-
-    it('pushes default_max_age to #validateIdToken', function () {
-      const client = new this.issuer.Client({
-        client_id: 'with-default_max_age',
-        client_secret: 'secure',
-        default_max_age: 300,
-      });
-
-      nock('https://op.example.com')
-        .post('/token')
-        .reply(200, {
-          id_token: 'foobar',
-        });
-
-      sinon.spy(client, 'validateIdToken');
-
-      return client.authorizationCallback('https://rp.example.com/cb', {
-        code: 'codeValue',
-      })
-        .then(fail, () => {
-          expect(client.validateIdToken.calledOnce).to.be.true;
-          expect(client.validateIdToken.firstCall.args[3]).to.equal(300);
-        });
-    });
-
-    it('rejects with OpenIdConnectError when part of the response', function () {
-      return this.client.authorizationCallback('https://rp.example.com/cb', {
-        error: 'invalid_request',
-      }).then(fail, (error) => {
-        expect(error).to.be.instanceof(OpenIdConnectError);
-        expect(error).to.have.property('message', 'invalid_request');
-      });
-    });
-
-    it('rejects with an Error when states mismatch (returned)', function () {
-      return this.client.authorizationCallback('https://rp.example.com/cb', {
-        state: 'should be checked for this',
-      }).then(fail, (error) => {
-        expect(error).to.be.instanceof(Error);
-        expect(error).to.have.property('message', 'state mismatch');
-      });
-    });
-
-    it('rejects with an Error when states mismatch (not returned)', function () {
-      return this.client.authorizationCallback('https://rp.example.com/cb', {}, {
-        state: 'should be this',
-      })
-        .then(fail, (error) => {
-          expect(error).to.be.instanceof(Error);
-          expect(error).to.have.property('message', 'state mismatch');
-        });
-    });
-
-    it('rejects with an Error when states mismatch (general mismatch)', function () {
-      return this.client.authorizationCallback('https://rp.example.com/cb', {
-        state: 'is this',
-      }, {
-        state: 'should be this',
-      })
-        .then(fail, (error) => {
-          expect(error).to.be.instanceof(Error);
-          expect(error).to.have.property('message', 'state mismatch');
-        });
-    });
-  });
-
-  describe('#oauthCallback', function () {
-    before(function () {
-      this.issuer = new Issuer({
-        token_endpoint: 'https://op.example.com/token',
-      });
-      this.client = new this.issuer.Client({
-        client_id: 'identifier',
-        client_secret: 'secure',
-      });
-    });
-
-    it('does an authorization_code grant with code and redirect_uri', function () {
-      nock('https://op.example.com')
-        .filteringRequestBody(function (body) {
-          expect(querystring.parse(body)).to.eql({
-            code: 'codeValue',
-            redirect_uri: 'https://rp.example.com/cb',
-            grant_type: 'authorization_code',
-          });
-        })
-        .post('/token')
-        .reply(200, {
-          access_token: 'tokenValue',
-        });
-
-      return this.client.oauthCallback('https://rp.example.com/cb', {
-        code: 'codeValue',
-      }).then((set) => {
-        expect(nock.isDone()).to.be.true;
-        expect(set).to.be.instanceof(TokenSet);
-        expect(set).to.have.property('access_token', 'tokenValue');
-      });
-    });
-
-    it('handles implicit responses too', function () {
-      return this.client.oauthCallback(undefined, {
-        access_token: 'tokenValue',
-      }).then((set) => {
-        expect(set).to.be.instanceof(TokenSet);
-        expect(set).to.have.property('access_token', 'tokenValue');
-      });
-    });
-
-    it('rejects with OpenIdConnectError when part of the response', function () {
-      return this.client.oauthCallback('https://rp.example.com/cb', {
-        error: 'invalid_request',
-      }).then(fail, (error) => {
-        expect(error).to.be.instanceof(OpenIdConnectError);
-        expect(error).to.have.property('message', 'invalid_request');
-      });
-    });
-
-    it('rejects with an Error when states mismatch (returned)', function () {
-      return this.client.oauthCallback('https://rp.example.com/cb', {
-        state: 'should be checked for this',
-      }).then(fail, (error) => {
-        expect(error).to.be.instanceof(Error);
-        expect(error).to.have.property('message', 'state mismatch');
-      });
-    });
-
-    it('rejects with an Error when states mismatch (not returned)', function () {
-      return this.client.oauthCallback('https://rp.example.com/cb', {}, {
-        state: 'should be this',
-      })
-        .then(fail, (error) => {
-          expect(error).to.be.instanceof(Error);
-          expect(error).to.have.property('message', 'state mismatch');
-        });
-    });
-
-    it('rejects with an Error when states mismatch (general mismatch)', function () {
-      return this.client.oauthCallback('https://rp.example.com/cb', {
-        state: 'is this',
-      }, {
-        state: 'should be this',
-      })
-        .then(fail, (error) => {
-          expect(error).to.be.instanceof(Error);
-          expect(error).to.have.property('message', 'state mismatch');
-        });
-    });
-  });
-
-
-  describe('#refresh', function () {
-    before(function () {
-      const issuer = new Issuer({
-        token_endpoint: 'https://op.example.com/token',
-      });
-      this.client = new issuer.Client({
-        client_id: 'identifier',
-        client_secret: 'secure',
-      });
-    });
-
-    it('does an refresh_token grant with refresh_token', function () {
-      nock('https://op.example.com')
-        .filteringRequestBody(function (body) {
-          expect(querystring.parse(body)).to.eql({
-            refresh_token: 'refreshValue',
-            grant_type: 'refresh_token',
-          });
-        })
-        .post('/token')
-        .reply(200, {});
-
-      return this.client.refresh('refreshValue').then(() => {
-        expect(nock.isDone()).to.be.true;
-      });
-    });
-
-    it('returns a TokenSet', function () {
-      nock('https://op.example.com')
-        .post('/token')
-        .reply(200, {
-          access_token: 'tokenValue',
-        });
-
-      return this.client.refresh('refreshValue', {})
-        .then((set) => {
           expect(set).to.be.instanceof(TokenSet);
           expect(set).to.have.property('access_token', 'tokenValue');
         });
+      });
+
+      it('handles implicit responses too', function () {
+        return this.client.oauthCallback(undefined, {
+          access_token: 'tokenValue',
+        }).then((set) => {
+          expect(set).to.be.instanceof(TokenSet);
+          expect(set).to.have.property('access_token', 'tokenValue');
+        });
+      });
+
+      it('rejects with OpenIdConnectError when part of the response', function () {
+        return this.client.oauthCallback('https://rp.example.com/cb', {
+          error: 'invalid_request',
+        }).then(fail, (error) => {
+          expect(error).to.be.instanceof(OpenIdConnectError);
+          expect(error).to.have.property('message', 'invalid_request');
+        });
+      });
+
+      it('rejects with an Error when states mismatch (returned)', function () {
+        return this.client.oauthCallback('https://rp.example.com/cb', {
+          state: 'should be checked for this',
+        }).then(fail, (error) => {
+          expect(error).to.be.instanceof(Error);
+          expect(error).to.have.property('message', 'state mismatch');
+        });
+      });
+
+      it('rejects with an Error when states mismatch (not returned)', function () {
+        return this.client.oauthCallback('https://rp.example.com/cb', {}, {
+          state: 'should be this',
+        })
+          .then(fail, (error) => {
+            expect(error).to.be.instanceof(Error);
+            expect(error).to.have.property('message', 'state mismatch');
+          });
+      });
+
+      it('rejects with an Error when states mismatch (general mismatch)', function () {
+        return this.client.oauthCallback('https://rp.example.com/cb', {
+          state: 'is this',
+        }, {
+          state: 'should be this',
+        })
+          .then(fail, (error) => {
+            expect(error).to.be.instanceof(Error);
+            expect(error).to.have.property('message', 'state mismatch');
+          });
+      });
     });
 
-    it('can take a TokenSet', function () {
-      nock('https://op.example.com')
-        .filteringRequestBody(function (body) {
-          expect(querystring.parse(body)).to.eql({
-            refresh_token: 'refreshValue',
-            grant_type: 'refresh_token',
-          });
-        })
-        .post('/token')
-        .reply(200, {});
 
-      return this.client.refresh(new TokenSet({
-        access_token: 'present',
-        refresh_token: 'refreshValue',
-      }))
-        .then(() => {
+    describe('#refresh', function () {
+      before(function () {
+        const issuer = new Issuer({
+          token_endpoint: 'https://op.example.com/token',
+        });
+        this.client = new issuer.Client({
+          client_id: 'identifier',
+          client_secret: 'secure',
+        });
+      });
+
+      it('does an refresh_token grant with refresh_token', function () {
+        nock('https://op.example.com')
+          .filteringRequestBody(function (body) {
+            expect(querystring.parse(body)).to.eql({
+              refresh_token: 'refreshValue',
+              grant_type: 'refresh_token',
+            });
+          })
+          .post('/token')
+          .reply(200, {});
+
+        return this.client.refresh('refreshValue').then(() => {
           expect(nock.isDone()).to.be.true;
         });
-    });
-
-    it('rejects when passed a TokenSet not containing refresh_token', function () {
-      return this.client.refresh(new TokenSet({
-        access_token: 'present',
-        // refresh_token: not
-      }))
-        .then(fail, (error) => {
-          expect(error).to.be.instanceof(Error);
-          expect(error).to.have.property('message', 'refresh_token not present in TokenSet');
-        });
-    });
-  });
-
-  it('#joseSecret', function () {
-    const client = new Client({ client_secret: 'rj_JR' });
-
-    return client.joseSecret()
-      .then((key) => {
-        expect(key).to.have.property('kty', 'oct');
-        return client.joseSecret().then((cached) => {
-          expect(key).to.equal(cached);
-        });
-      });
-  });
-
-  it('#derivedKey', function () {
-    const client = new Client({ client_secret: 'rj_JR' });
-
-    return client.derivedKey('128')
-      .then((key) => {
-        expect(key).to.have.property('kty', 'oct');
-        return client.derivedKey('128').then((cached) => {
-          expect(key).to.equal(cached);
-        });
-      });
-  });
-
-  it('#inspect', function () {
-    const issuer = new Issuer({ issuer: 'https://op.example.com' });
-    const client = new issuer.Client({ client_id: 'identifier' });
-    expect(client.inspect()).to.equal('Client <identifier>');
-  });
-
-  describe('#userinfo', function () {
-    it('takes a string token', function () {
-      const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
-      const client = new issuer.Client();
-
-      nock('https://op.example.com')
-        .get('/me').reply(200, {});
-
-      return client.userinfo('tokenValue').then(() => {
-        expect(nock.isDone()).to.be.true;
-      });
-    });
-
-    it('takes a tokenset', function () {
-      const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
-      const client = new issuer.Client({
-        id_token_signed_response_alg: 'none',
       });
 
-      nock('https://op.example.com')
-        .get('/me').reply(200, {
-          sub: 'subject',
-        });
-
-      return client.userinfo(new TokenSet({
-        id_token: 'eyJhbGciOiJub25lIn0.eyJzdWIiOiJzdWJqZWN0In0.',
-        refresh_token: 'bar',
-        access_token: 'tokenValue',
-      })).then(() => {
-        expect(nock.isDone()).to.be.true;
-      });
-    });
-
-    it('takes a tokenset and validates the subject in id_token is the same in userinfo', function () {
-      const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
-      const client = new issuer.Client({
-        id_token_signed_response_alg: 'none',
-      });
-
-      nock('https://op.example.com')
-        .get('/me').reply(200, {
-          sub: 'different-subject',
-        });
-
-      return client.userinfo(new TokenSet({
-        id_token: 'eyJhbGciOiJub25lIn0.eyJzdWIiOiJzdWJqZWN0In0.',
-        refresh_token: 'bar',
-        access_token: 'tokenValue',
-      })).then(fail, (err) => {
-        expect(nock.isDone()).to.be.true;
-        expect(err.message).to.equal('userinfo sub mismatch');
-      });
-    });
-
-    it('validates an access token is present in the tokenset', function () {
-      const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
-      const client = new issuer.Client();
-
-      return client.userinfo(new TokenSet({
-        id_token: 'foo',
-        refresh_token: 'bar',
-      })).then(fail, (error) => {
-        expect(error.message).to.equal('access_token not present in TokenSet');
-      });
-    });
-
-    it('can do a post call', function () {
-      const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
-      const client = new issuer.Client();
-
-      nock('https://op.example.com')
-        .post('/me').reply(200, {});
-
-      return client.userinfo('tokenValue', { verb: 'POST' }).then(() => {
-        expect(nock.isDone()).to.be.true;
-      });
-    });
-
-    it('can submit access token in a body when post', function () {
-      const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
-      const client = new issuer.Client();
-
-      nock('https://op.example.com')
-        .filteringRequestBody(function (body) {
-          expect(querystring.parse(body)).to.eql({
+      it('returns a TokenSet', function () {
+        nock('https://op.example.com')
+          .post('/token')
+          .reply(200, {
             access_token: 'tokenValue',
           });
-        })
-        .post('/me').reply(200, {});
 
-      return client.userinfo('tokenValue', { verb: 'POST', via: 'body' }).then(() => {
-        expect(nock.isDone()).to.be.true;
-      });
-    });
-
-    it('can add extra params in a body when post', function () {
-      const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
-      const client = new issuer.Client();
-
-      nock('https://op.example.com')
-        .filteringRequestBody(function (body) {
-          expect(querystring.parse(body)).to.eql({
-            access_token: 'tokenValue',
-            foo: 'bar',
+        return this.client.refresh('refreshValue', {})
+          .then((set) => {
+            expect(set).to.be.instanceof(TokenSet);
+            expect(set).to.have.property('access_token', 'tokenValue');
           });
-        })
-        .post('/me').reply(200, {});
-
-      return client.userinfo('tokenValue', {
-        verb: 'POST',
-        via: 'body',
-        params: { foo: 'bar' },
-      }).then(() => {
-        expect(nock.isDone()).to.be.true;
       });
-    });
 
-    it('can add extra params in a query when non-post', function () {
-      const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
-      const client = new issuer.Client();
-
-      nock('https://op.example.com')
-        .get('/me?foo=bar')
-        .reply(200, {});
-
-      return client.userinfo('tokenValue', {
-        params: { foo: 'bar' },
-      }).then(() => {
-        expect(nock.isDone()).to.be.true;
-      });
-    });
-
-    it('can only submit access token in a body when post', function () {
-      const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
-      const client = new issuer.Client();
-
-      expect(function () {
-        client.userinfo('tokenValue', { via: 'body', verb: 'get' });
-      }).to.throw('can only send body on POST');
-    });
-
-    it('can submit access token in a query when get', function () {
-      const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
-      const client = new issuer.Client();
-
-      nock('https://op.example.com')
-        .get('/me?access_token=tokenValue')
-        .reply(200, {});
-
-      return client.userinfo('tokenValue', { via: 'query' }).then(() => {
-        expect(nock.isDone()).to.be.true;
-      });
-    });
-
-    it('can only submit access token in a query when get', function () {
-      const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
-      const client = new issuer.Client();
-
-      expect(function () {
-        client.userinfo('tokenValue', { via: 'query', verb: 'post' });
-      }).to.throw('providers should only parse query strings for GET requests');
-    });
-
-    it('is rejected with OpenIdConnectError upon oidc error', function () {
-      const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
-      const client = new issuer.Client();
-
-      nock('https://op.example.com')
-        .get('/me')
-        .reply(401, {
-          error: 'invalid_token',
-          error_description: 'bad things are happening',
-        });
-
-      return client.userinfo()
-        .then(fail, function (error) {
-          expect(error.name).to.equal('OpenIdConnectError');
-          expect(error).to.have.property('message', 'invalid_token');
-        });
-    });
-
-    it('is rejected with when non 200 is returned', function () {
-      const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
-      const client = new issuer.Client();
-
-      nock('https://op.example.com')
-        .get('/me')
-        .reply(500, 'Internal Server Error');
-
-      return client.userinfo()
-        .then(fail, function (error) {
-          expect(error).to.be.an.instanceof(issuer.httpClient.HTTPError);
-        });
-    });
-
-    it('is rejected with JSON.parse error upon invalid response', function () {
-      const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
-      const client = new issuer.Client();
-
-      nock('https://op.example.com')
-        .get('/me')
-        .reply(200, '{"notavalid"}');
-
-      return client.userinfo()
-        .then(fail, function (error) {
-          expect(error).to.be.an.instanceof(SyntaxError);
-          expect(error).to.have.property('message').matches(/Unexpected token/);
-        });
-    });
-
-    describe('signed response (content-type = application/jwt)', function () {
-      it('decodes and validates the id_token', function () {
-        const issuer = new Issuer({
-          userinfo_endpoint: 'https://op.example.com/me',
-          issuer: 'https://op.example.com',
-        });
-        const client = new issuer.Client({
-          client_id: 'foobar',
-          userinfo_signed_response_alg: 'none',
-        });
-
-        const payload = {
-          iss: issuer.issuer,
-          sub: 'foobar',
-          aud: client.client_id,
-          exp: now() + 100,
-          iat: now(),
-        };
-
+      it('can take a TokenSet', function () {
         nock('https://op.example.com')
-          .get('/me')
-          .reply(200, `${encode({ alg: 'none' })}.${encode(payload)}.`, {
-            'content-type': 'application/jwt; charset=utf-8',
-          });
-
-        return client.userinfo('accessToken')
-          .then((userinfo) => {
-            expect(userinfo).to.be.an('object');
-            expect(userinfo).to.eql(payload);
-          });
-      });
-
-      it('validates the used alg of signed userinfo', function () {
-        const issuer = new Issuer({
-          userinfo_endpoint: 'https://op.example.com/me',
-          issuer: 'https://op.example.com',
-        });
-        const client = new issuer.Client({
-          client_id: 'foobar',
-          userinfo_signed_response_alg: 'RS256',
-        });
-
-        const payload = {};
-
-        nock('https://op.example.com')
-          .get('/me')
-          .reply(200, `${encode({ alg: 'none' })}.${encode(payload)}.`, {
-            'content-type': 'application/jwt; charset=utf-8',
-          });
-
-        return client.userinfo().then(fail, (err) => {
-          expect(err.message).to.eql('unexpected algorithm received');
-        });
-      });
-    });
-  });
-
-  _.forEach({
-    introspect: 'introspection_endpoint',
-    revoke: 'revocation_endpoint',
-  }, function (endpoint, method) {
-    describe(`#${method}`, function () {
-      it('posts the token in a body and returns the parsed response', function () {
-        nock('https://rp.example.com')
           .filteringRequestBody(function (body) {
             expect(querystring.parse(body)).to.eql({
-              token: 'tokenValue',
+              refresh_token: 'refreshValue',
+              grant_type: 'refresh_token',
             });
           })
-          .post(`/token/${method}`)
-          .reply(200, {
-            endpoint: 'response',
+          .post('/token')
+          .reply(200, {});
+
+        return this.client.refresh(new TokenSet({
+          access_token: 'present',
+          refresh_token: 'refreshValue',
+        }))
+          .then(() => {
+            expect(nock.isDone()).to.be.true;
           });
-
-        const issuer = new Issuer({
-          [endpoint]: `https://rp.example.com/token/${method}`,
-        });
-        const client = new issuer.Client();
-
-        return client[method]('tokenValue')
-          .then(response => expect(response).to.eql({ endpoint: 'response' }));
       });
 
-      it('posts the token and a hint in a body', function () {
-        nock('https://rp.example.com')
+      it('rejects when passed a TokenSet not containing refresh_token', function () {
+        return this.client.refresh(new TokenSet({
+          access_token: 'present',
+          // refresh_token: not
+        }))
+          .then(fail, (error) => {
+            expect(error).to.be.instanceof(Error);
+            expect(error).to.have.property('message', 'refresh_token not present in TokenSet');
+          });
+      });
+    });
+
+    it('#joseSecret', function () {
+      const client = new Client({ client_secret: 'rj_JR' });
+
+      return client.joseSecret()
+        .then((key) => {
+          expect(key).to.have.property('kty', 'oct');
+          return client.joseSecret().then((cached) => {
+            expect(key).to.equal(cached);
+          });
+        });
+    });
+
+    it('#derivedKey', function () {
+      const client = new Client({ client_secret: 'rj_JR' });
+
+      return client.derivedKey('128')
+        .then((key) => {
+          expect(key).to.have.property('kty', 'oct');
+          return client.derivedKey('128').then((cached) => {
+            expect(key).to.equal(cached);
+          });
+        });
+    });
+
+    it('#inspect', function () {
+      const issuer = new Issuer({ issuer: 'https://op.example.com' });
+      const client = new issuer.Client({ client_id: 'identifier' });
+      expect(client.inspect()).to.equal('Client <identifier>');
+    });
+
+    describe('#userinfo', function () {
+      it('takes a string token', function () {
+        const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
+        const client = new issuer.Client();
+
+        nock('https://op.example.com')
+          .get('/me').reply(200, {});
+
+        return client.userinfo('tokenValue').then(() => {
+          expect(nock.isDone()).to.be.true;
+        });
+      });
+
+      it('takes a tokenset', function () {
+        const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
+        const client = new issuer.Client({
+          id_token_signed_response_alg: 'none',
+        });
+
+        nock('https://op.example.com')
+          .get('/me').reply(200, {
+            sub: 'subject',
+          });
+
+        return client.userinfo(new TokenSet({
+          id_token: 'eyJhbGciOiJub25lIn0.eyJzdWIiOiJzdWJqZWN0In0.',
+          refresh_token: 'bar',
+          access_token: 'tokenValue',
+        })).then(() => {
+          expect(nock.isDone()).to.be.true;
+        });
+      });
+
+      it('takes a tokenset and validates the subject in id_token is the same in userinfo', function () {
+        const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
+        const client = new issuer.Client({
+          id_token_signed_response_alg: 'none',
+        });
+
+        nock('https://op.example.com')
+          .get('/me').reply(200, {
+            sub: 'different-subject',
+          });
+
+        return client.userinfo(new TokenSet({
+          id_token: 'eyJhbGciOiJub25lIn0.eyJzdWIiOiJzdWJqZWN0In0.',
+          refresh_token: 'bar',
+          access_token: 'tokenValue',
+        })).then(fail, (err) => {
+          expect(nock.isDone()).to.be.true;
+          expect(err.message).to.equal('userinfo sub mismatch');
+        });
+      });
+
+      it('validates an access token is present in the tokenset', function () {
+        const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
+        const client = new issuer.Client();
+
+        return client.userinfo(new TokenSet({
+          id_token: 'foo',
+          refresh_token: 'bar',
+        })).then(fail, (error) => {
+          expect(error.message).to.equal('access_token not present in TokenSet');
+        });
+      });
+
+      it('can do a post call', function () {
+        const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
+        const client = new issuer.Client();
+
+        nock('https://op.example.com')
+          .post('/me').reply(200, {});
+
+        return client.userinfo('tokenValue', { verb: 'POST' }).then(() => {
+          expect(nock.isDone()).to.be.true;
+        });
+      });
+
+      it('can submit access token in a body when post', function () {
+        const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
+        const client = new issuer.Client();
+
+        nock('https://op.example.com')
           .filteringRequestBody(function (body) {
             expect(querystring.parse(body)).to.eql({
-              token: 'tokenValue',
-              token_type_hint: 'access_token',
+              access_token: 'tokenValue',
             });
           })
-          .post(`/token/${method}`)
-          .reply(200, {
-            endpoint: 'response',
-          });
+          .post('/me').reply(200, {});
 
-        const issuer = new Issuer({
-          [endpoint]: `https://rp.example.com/token/${method}`,
+        return client.userinfo('tokenValue', { verb: 'POST', via: 'body' }).then(() => {
+          expect(nock.isDone()).to.be.true;
         });
-        const client = new issuer.Client();
-
-        return client[method]('tokenValue', 'access_token');
       });
 
-      it('validates the hint is a string', function () {
-        const issuer = new Issuer({
-          [endpoint]: `https://rp.example.com/token/${method}`,
-        });
+      it('can add extra params in a body when post', function () {
+        const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
         const client = new issuer.Client();
+
+        nock('https://op.example.com')
+          .filteringRequestBody(function (body) {
+            expect(querystring.parse(body)).to.eql({
+              access_token: 'tokenValue',
+              foo: 'bar',
+            });
+          })
+          .post('/me').reply(200, {});
+
+        return client.userinfo('tokenValue', {
+          verb: 'POST',
+          via: 'body',
+          params: { foo: 'bar' },
+        }).then(() => {
+          expect(nock.isDone()).to.be.true;
+        });
+      });
+
+      it('can add extra params in a query when non-post', function () {
+        const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
+        const client = new issuer.Client();
+
+        nock('https://op.example.com')
+          .get('/me?foo=bar')
+          .reply(200, {});
+
+        return client.userinfo('tokenValue', {
+          params: { foo: 'bar' },
+        }).then(() => {
+          expect(nock.isDone()).to.be.true;
+        });
+      });
+
+      it('can only submit access token in a body when post', function () {
+        const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
+        const client = new issuer.Client();
+
         expect(function () {
-          client[method]('tokenValue', { nonstring: 'value' });
-        }).to.throw('hint must be a string');
+          client.userinfo('tokenValue', { via: 'body', verb: 'get' });
+        }).to.throw('can only send body on POST');
+      });
+
+      it('can submit access token in a query when get', function () {
+        const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
+        const client = new issuer.Client();
+
+        nock('https://op.example.com')
+          .get('/me?access_token=tokenValue')
+          .reply(200, {});
+
+        return client.userinfo('tokenValue', { via: 'query' }).then(() => {
+          expect(nock.isDone()).to.be.true;
+        });
+      });
+
+      it('can only submit access token in a query when get', function () {
+        const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
+        const client = new issuer.Client();
+
+        expect(function () {
+          client.userinfo('tokenValue', { via: 'query', verb: 'post' });
+        }).to.throw('providers should only parse query strings for GET requests');
       });
 
       it('is rejected with OpenIdConnectError upon oidc error', function () {
-        nock('https://rp.example.com')
-          .post(`/token/${method}`)
-          .reply(500, {
-            error: 'server_error',
+        const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
+        const client = new issuer.Client();
+
+        nock('https://op.example.com')
+          .get('/me')
+          .reply(401, {
+            error: 'invalid_token',
             error_description: 'bad things are happening',
           });
 
-        const issuer = new Issuer({
-          [endpoint]: `https://rp.example.com/token/${method}`,
-        });
-        const client = new issuer.Client();
-
-        return client[method]('tokenValue')
+        return client.userinfo()
           .then(fail, function (error) {
-            expect(error).to.have.property('message', 'server_error');
+            expect(error.name).to.equal('OpenIdConnectError');
+            expect(error).to.have.property('message', 'invalid_token');
           });
       });
 
       it('is rejected with when non 200 is returned', function () {
-        nock('https://rp.example.com')
-          .post(`/token/${method}`)
-          .reply(500, 'Internal Server Error');
-
-        const issuer = new Issuer({
-          [endpoint]: `https://rp.example.com/token/${method}`,
-        });
+        const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
         const client = new issuer.Client();
 
-        return client[method]('tokenValue')
+        nock('https://op.example.com')
+          .get('/me')
+          .reply(500, 'Internal Server Error');
+
+        return client.userinfo()
           .then(fail, function (error) {
             expect(error).to.be.an.instanceof(issuer.httpClient.HTTPError);
           });
       });
 
       it('is rejected with JSON.parse error upon invalid response', function () {
-        nock('https://rp.example.com')
-          .post(`/token/${method}`)
-          .reply(200, '{"notavalid"}');
-
-        const issuer = new Issuer({
-          [endpoint]: `https://rp.example.com/token/${method}`,
-        });
+        const issuer = new Issuer({ userinfo_endpoint: 'https://op.example.com/me' });
         const client = new issuer.Client();
 
-        return client[method]('tokenValue')
+        nock('https://op.example.com')
+          .get('/me')
+          .reply(200, '{"notavalid"}');
+
+        return client.userinfo()
           .then(fail, function (error) {
             expect(error).to.be.an.instanceof(SyntaxError);
             expect(error).to.have.property('message').matches(/Unexpected token/);
           });
       });
 
-      if (method === 'revoke') {
-        it('handles empty bodies', function () {
+      describe('signed response (content-type = application/jwt)', function () {
+        it('decodes and validates the id_token', function () {
+          const issuer = new Issuer({
+            userinfo_endpoint: 'https://op.example.com/me',
+            issuer: 'https://op.example.com',
+          });
+          const client = new issuer.Client({
+            client_id: 'foobar',
+            userinfo_signed_response_alg: 'none',
+          });
+
+          const payload = {
+            iss: issuer.issuer,
+            sub: 'foobar',
+            aud: client.client_id,
+            exp: now() + 100,
+            iat: now(),
+          };
+
+          nock('https://op.example.com')
+            .get('/me')
+            .reply(200, `${encode({ alg: 'none' })}.${encode(payload)}.`, {
+              'content-type': 'application/jwt; charset=utf-8',
+            });
+
+          return client.userinfo('accessToken')
+            .then((userinfo) => {
+              expect(userinfo).to.be.an('object');
+              expect(userinfo).to.eql(payload);
+            });
+        });
+
+        it('validates the used alg of signed userinfo', function () {
+          const issuer = new Issuer({
+            userinfo_endpoint: 'https://op.example.com/me',
+            issuer: 'https://op.example.com',
+          });
+          const client = new issuer.Client({
+            client_id: 'foobar',
+            userinfo_signed_response_alg: 'RS256',
+          });
+
+          const payload = {};
+
+          nock('https://op.example.com')
+            .get('/me')
+            .reply(200, `${encode({ alg: 'none' })}.${encode(payload)}.`, {
+              'content-type': 'application/jwt; charset=utf-8',
+            });
+
+          return client.userinfo().then(fail, (err) => {
+            expect(err.message).to.eql('unexpected algorithm received');
+          });
+        });
+      });
+    });
+
+    _.forEach({
+      introspect: 'introspection_endpoint',
+      revoke: 'revocation_endpoint',
+    }, function (endpoint, method) {
+      describe(`#${method}`, function () {
+        it('posts the token in a body and returns the parsed response', function () {
           nock('https://rp.example.com')
+            .filteringRequestBody(function (body) {
+              expect(querystring.parse(body)).to.eql({
+                token: 'tokenValue',
+              });
+            })
             .post(`/token/${method}`)
-            .reply(200);
+            .reply(200, {
+              endpoint: 'response',
+            });
 
           const issuer = new Issuer({
             [endpoint]: `https://rp.example.com/token/${method}`,
           });
           const client = new issuer.Client();
 
-          return client[method]('tokenValue').then((response) => {
-            expect(response).to.eql({});
+          return client[method]('tokenValue')
+            .then(response => expect(response).to.eql({ endpoint: 'response' }));
+        });
+
+        it('posts the token and a hint in a body', function () {
+          nock('https://rp.example.com')
+            .filteringRequestBody(function (body) {
+              expect(querystring.parse(body)).to.eql({
+                token: 'tokenValue',
+                token_type_hint: 'access_token',
+              });
+            })
+            .post(`/token/${method}`)
+            .reply(200, {
+              endpoint: 'response',
+            });
+
+          const issuer = new Issuer({
+            [endpoint]: `https://rp.example.com/token/${method}`,
+          });
+          const client = new issuer.Client();
+
+          return client[method]('tokenValue', 'access_token');
+        });
+
+        it('validates the hint is a string', function () {
+          const issuer = new Issuer({
+            [endpoint]: `https://rp.example.com/token/${method}`,
+          });
+          const client = new issuer.Client();
+          expect(function () {
+            client[method]('tokenValue', { nonstring: 'value' });
+          }).to.throw('hint must be a string');
+        });
+
+        it('is rejected with OpenIdConnectError upon oidc error', function () {
+          nock('https://rp.example.com')
+            .post(`/token/${method}`)
+            .reply(500, {
+              error: 'server_error',
+              error_description: 'bad things are happening',
+            });
+
+          const issuer = new Issuer({
+            [endpoint]: `https://rp.example.com/token/${method}`,
+          });
+          const client = new issuer.Client();
+
+          return client[method]('tokenValue')
+            .then(fail, function (error) {
+              expect(error).to.have.property('message', 'server_error');
+            });
+        });
+
+        it('is rejected with when non 200 is returned', function () {
+          nock('https://rp.example.com')
+            .post(`/token/${method}`)
+            .reply(500, 'Internal Server Error');
+
+          const issuer = new Issuer({
+            [endpoint]: `https://rp.example.com/token/${method}`,
+          });
+          const client = new issuer.Client();
+
+          return client[method]('tokenValue')
+            .then(fail, function (error) {
+              expect(error).to.be.an.instanceof(issuer.httpClient.HTTPError);
+            });
+        });
+
+        it('is rejected with JSON.parse error upon invalid response', function () {
+          nock('https://rp.example.com')
+            .post(`/token/${method}`)
+            .reply(200, '{"notavalid"}');
+
+          const issuer = new Issuer({
+            [endpoint]: `https://rp.example.com/token/${method}`,
+          });
+          const client = new issuer.Client();
+
+          return client[method]('tokenValue')
+            .then(fail, function (error) {
+              expect(error).to.be.an.instanceof(SyntaxError);
+              expect(error).to.have.property('message').matches(/Unexpected token/);
+            });
+        });
+
+        if (method === 'revoke') {
+          it('handles empty bodies', function () {
+            nock('https://rp.example.com')
+              .post(`/token/${method}`)
+              .reply(200);
+
+            const issuer = new Issuer({
+              [endpoint]: `https://rp.example.com/token/${method}`,
+            });
+            const client = new issuer.Client();
+
+            return client[method]('tokenValue').then((response) => {
+              expect(response).to.eql({});
+            });
+          });
+        }
+      });
+    });
+
+    describe('#grant', function () {
+      it('calls authenticatedPost with token endpoint and body', function () {
+        const issuer = new Issuer({ token_endpoint: 'https://op.example.com/token' });
+        const client = new issuer.Client();
+
+        sinon.spy(client, 'authenticatedPost');
+
+        client.grant({
+          token: 'tokenValue',
+        }).then(noop, noop);
+
+        expect(client.authenticatedPost.args[0][0]).to.equal('token');
+        expect(client.authenticatedPost.args[0][1]).to.eql({ body: { token: 'tokenValue' } });
+      });
+    });
+
+    describe('#authFor', function () {
+      context('when none', function () {
+        it('returns the body httpOptions', function () {
+          const client = new Client({
+            client_id: 'identifier',
+            client_secret: 'secure',
+            token_endpoint_auth_method: 'none',
+          });
+          expect(client.authFor('token')).to.eql({
+            body: { client_id: 'identifier' },
           });
         });
-      }
-    });
-  });
-
-  describe('#grant', function () {
-    it('calls authenticatedPost with token endpoint and body', function () {
-      const issuer = new Issuer({ token_endpoint: 'https://op.example.com/token' });
-      const client = new issuer.Client();
-
-      sinon.spy(client, 'authenticatedPost');
-
-      client.grant({
-        token: 'tokenValue',
-      }).then(noop, noop);
-
-      expect(client.authenticatedPost.args[0][0]).to.equal('token');
-      expect(client.authenticatedPost.args[0][1]).to.eql({ body: { token: 'tokenValue' } });
-    });
-  });
-
-  describe('#authFor', function () {
-    context('when none', function () {
-      it('returns the body httpOptions', function () {
-        const client = new Client({
-          client_id: 'identifier',
-          client_secret: 'secure',
-          token_endpoint_auth_method: 'none',
-        });
-        expect(client.authFor('token')).to.eql({
-          body: { client_id: 'identifier' },
-        });
-      });
-    });
-
-    context('when client_secret_post', function () {
-      it('returns the body httpOptions', function () {
-        const client = new Client({
-          client_id: 'identifier',
-          client_secret: 'secure',
-          token_endpoint_auth_method: 'client_secret_post',
-        });
-        expect(client.authFor('token')).to.eql({
-          body: { client_id: 'identifier', client_secret: 'secure' },
-        });
-      });
-    });
-
-    context('when client_secret_basic', function () {
-      it('is the default', function () {
-        const client = new Client({ client_id: 'identifier', client_secret: 'secure' });
-        expect(client.authFor('token')).to.eql({
-          headers: { Authorization: 'Basic aWRlbnRpZmllcjpzZWN1cmU=' },
-        });
-      });
-    });
-
-    context('when client_secret_jwt', function () {
-      before(function () {
-        const issuer = new Issuer({
-          token_endpoint: 'https://rp.example.com/token',
-          token_endpoint_auth_signing_alg_values_supported: ['HS256', 'HS384'],
-        });
-
-        const client = new issuer.Client({
-          client_id: 'identifier',
-          client_secret: 'its gotta be a long secret and i mean at least 32 characters',
-          token_endpoint_auth_method: 'client_secret_jwt',
-        });
-
-        return client.authFor('token').then((auth) => { this.auth = auth; });
       });
 
-      it('promises a body', function () {
-        expect(this.auth).to.have.property('body').and.is.an('object');
-        expect(this.auth.body).to.have.property(
-          'client_assertion_type',
-          'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
-        );
-        expect(this.auth.body).to.have.property('client_assertion');
-      });
-
-      it('has a predefined payload properties', function () {
-        const payload = JSON.parse(base64url.decode(this.auth.body.client_assertion.split('.')[1]));
-        expect(payload).to.have.keys(['iat', 'exp', 'jti', 'iss', 'sub', 'aud']);
-
-        expect(payload.iss).to.equal(payload.sub).to.equal('identifier');
-        expect(payload.jti).to.be.a('string');
-        expect(payload.iat).to.be.a('number');
-        expect(payload.exp).to.be.a('number');
-        expect(payload.aud).to.equal('https://rp.example.com/token');
-      });
-
-      it('has the right header properties', function () {
-        const header = JSON.parse(base64url.decode(this.auth.body.client_assertion.split('.')[0]));
-        expect(header).to.have.keys([
-          'alg', 'typ',
-        ]);
-
-        expect(header.alg).to.equal('HS256');
-        expect(header.typ).to.equal('JWT');
-      });
-    });
-
-    context('when private_key_jwt', function () {
-      before(function () {
-        const issuer = new Issuer({
-          token_endpoint: 'https://rp.example.com/token',
-          token_endpoint_auth_signing_alg_values_supported: ['ES256', 'ES384'],
+      context('when client_secret_post', function () {
+        it('returns the body httpOptions', function () {
+          const client = new Client({
+            client_id: 'identifier',
+            client_secret: 'secure',
+            token_endpoint_auth_method: 'client_secret_post',
+          });
+          expect(client.authFor('token')).to.eql({
+            body: { client_id: 'identifier', client_secret: 'secure' },
+          });
         });
+      });
 
-        const keystore = jose.JWK.createKeyStore();
+      context('when client_secret_basic', function () {
+        it('is the default', function () {
+          const client = new Client({ client_id: 'identifier', client_secret: 'secure' });
+          expect(client.authFor('token')).to.eql({
+            headers: { Authorization: 'Basic aWRlbnRpZmllcjpzZWN1cmU=' },
+          });
+        });
+      });
 
-        return keystore.generate('EC', 'P-256').then(() => {
+      context('when client_secret_jwt', function () {
+        before(function () {
+          const issuer = new Issuer({
+            token_endpoint: 'https://rp.example.com/token',
+            token_endpoint_auth_signing_alg_values_supported: ['HS256', 'HS384'],
+          });
+
           const client = new issuer.Client({
             client_id: 'identifier',
-            token_endpoint_auth_method: 'private_key_jwt',
-          }, keystore);
+            client_secret: 'its gotta be a long secret and i mean at least 32 characters',
+            token_endpoint_auth_method: 'client_secret_jwt',
+          });
 
           return client.authFor('token').then((auth) => { this.auth = auth; });
         });
-      });
 
-      it('promises a body', function () {
-        expect(this.auth).to.have.property('body').and.is.an('object');
-        expect(this.auth.body).to.have.property(
-          'client_assertion_type',
-          'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
-        );
-        expect(this.auth.body).to.have.property('client_assertion');
-      });
-
-      it('has a predefined payload properties', function () {
-        const payload = JSON.parse(base64url.decode(this.auth.body.client_assertion.split('.')[1]));
-        expect(payload).to.have.keys(['iat', 'exp', 'jti', 'iss', 'sub', 'aud']);
-
-        expect(payload.iss).to.equal(payload.sub).to.equal('identifier');
-        expect(payload.jti).to.be.a('string');
-        expect(payload.iat).to.be.a('number');
-        expect(payload.exp).to.be.a('number');
-        expect(payload.aud).to.equal('https://rp.example.com/token');
-      });
-
-      it('has the right header properties', function () {
-        const header = JSON.parse(base64url.decode(this.auth.body.client_assertion.split('.')[0]));
-        expect(header).to.have.keys([
-          'alg', 'typ', 'kid',
-        ]);
-
-        expect(header.alg).to.equal('ES256');
-        expect(header.typ).to.equal('JWT');
-        expect(header.kid).to.be.ok;
-      });
-    });
-  });
-});
-
-describe('Client#validateIdToken', function () {
-  afterEach(function () {
-    if (this.client) this.client.CLOCK_TOLERANCE = 0;
-  });
-
-  before(function () {
-    this.keystore = jose.JWK.createKeyStore();
-    return this.keystore.generate('RSA', 512);
-  });
-
-  before(function () {
-    this.issuer = new Issuer({
-      issuer: 'https://op.example.com',
-      jwks_uri: 'https://op.example.com/certs',
-    });
-    this.client = new this.issuer.Client({
-      client_id: 'identifier',
-      client_secret: 'its gotta be a long secret and i mean at least 32 characters',
-    });
-
-    this.IdToken = class IdToken {
-      constructor(key, alg, payload) {
-        return jose.JWS.createSign({
-          fields: { alg, typ: 'JWT' },
-          format: 'compact',
-        }, { key, reference: !alg.startsWith('HS') }).update(JSON.stringify(payload)).final();
-      }
-    };
-  });
-
-  before(function () {
-    nock('https://op.example.com')
-      .persist()
-      .get('/certs')
-      .reply(200, this.keystore.toJSON());
-  });
-
-  after(nock.cleanAll);
-
-  it('validates the id token and fulfills with input value (when string)', function () {
-    return new this.IdToken(this.keystore.get(), 'RS256', {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    })
-      .then(token => this.client.validateIdToken(token).then((validated) => {
-        expect(validated).to.equal(token);
-      }));
-  });
-
-  it('validates the id token and fulfills with input value (when TokenSet)', function () {
-    return new this.IdToken(this.keystore.get(), 'RS256', {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    })
-      .then((token) => {
-        const tokenset = new TokenSet({ id_token: token });
-        return this.client.validateIdToken(tokenset).then((validated) => {
-          expect(validated).to.equal(tokenset);
-        });
-      });
-  });
-
-  it('validates the id token signature (when string)', function () {
-    return new this.IdToken(this.keystore.get(), 'RS256', {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    })
-      .then(token => this.client.validateIdToken(token.slice(0, -1)).then(fail, (err) => {
-        expect(err.message).to.equal('invalid signature');
-      }));
-  });
-
-  it('validates the id token signature (when TokenSet)', function () {
-    return new this.IdToken(this.keystore.get(), 'RS256', {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    })
-      .then((token) => {
-        const tokenset = new TokenSet({ id_token: token.slice(0, -1) });
-        return this.client.validateIdToken(tokenset).then(fail, (err) => {
-          expect(err.message).to.equal('invalid signature');
-        });
-      });
-  });
-
-  it('validates the id token and fulfills with input value (when signed by secret)', function () {
-    const client = new this.issuer.Client({
-      client_id: 'hs256-client',
-      client_secret: 'its gotta be a long secret and i mean at least 32 characters',
-      id_token_signed_response_alg: 'HS256',
-    });
-
-    return client.joseSecret().then((key) => {
-      return new this.IdToken(key, 'HS256', {
-        iss: this.issuer.issuer,
-        sub: 'userId',
-        aud: client.client_id,
-        exp: now() + 3600,
-        iat: now(),
-      })
-        .then((token) => {
-          const tokenset = new TokenSet({ id_token: token });
-          return client.validateIdToken(tokenset).then((validated) => {
-            expect(validated).to.equal(tokenset);
-          });
-        });
-    });
-  });
-
-  it('can be also used for userinfo response validation', function () {
-    const client = new this.issuer.Client({
-      client_id: 'hs256-client',
-      client_secret: 'its gotta be a long secret and i mean at least 32 characters',
-      userinfo_signed_response_alg: 'HS256',
-    });
-
-    return client.joseSecret().then((key) => {
-      return new this.IdToken(key, 'HS256', {
-        iss: this.issuer.issuer,
-        sub: 'userId',
-        aud: client.client_id,
-        exp: now() + 3600,
-        iat: now(),
-      })
-        .then((token) => {
-          return client.validateIdToken(token, null, 'userinfo').then((validated) => {
-            expect(validated).to.equal(token);
-          });
-        });
-    });
-  });
-
-  it('validates the id_token_signed_response_alg is the one used', function () {
-    return this.client.joseSecret().then((key) => {
-      return new this.IdToken(key, 'HS256', {
-        iss: this.issuer.issuer,
-        sub: 'userId',
-        aud: this.client.client_id,
-        exp: now() + 3600,
-        iat: now(),
-      })
-        .then(token => this.client.validateIdToken(token))
-        .then(fail, (error) => {
-          expect(error).to.have.property('message', 'unexpected algorithm received');
-        });
-    });
-  });
-
-  it('verifies the azp', function () {
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      azp: 'not the client',
-      exp: now() + 3600,
-      iat: now(),
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token))
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 'azp must be the client_id');
-      });
-  });
-
-  it('verifies azp is present when more audiences are provided', function () {
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: [this.client.client_id, 'someone else'],
-      exp: now() + 3600,
-      iat: now(),
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token))
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 'missing required JWT property azp');
-      });
-  });
-
-  it('verifies the audience when azp is there', function () {
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: [this.client.client_id, 'someone else'],
-      azp: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token));
-  });
-
-  it('passes with nonce check', function () {
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      nonce: 'nonce!!!',
-      aud: [this.client.client_id, 'someone else'],
-      azp: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token, 'nonce!!!'));
-  });
-
-  it('validates nonce when provided to check for', function () {
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: [this.client.client_id, 'someone else'],
-      azp: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token, 'nonce!!!'))
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 'nonce mismatch');
-      });
-  });
-
-  it('validates nonce when in token', function () {
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      nonce: 'nonce!!!',
-      aud: [this.client.client_id, 'someone else'],
-      azp: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token))
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 'nonce mismatch');
-      });
-  });
-
-  ['iss', 'sub', 'aud', 'exp', 'iat'].forEach(function (prop) {
-    it(`verifies presence of payload property ${prop}`, function () {
-      const payload = {
-        iss: this.issuer.issuer,
-        sub: 'userId',
-        aud: this.client.client_id,
-        exp: now() + 3600,
-        iat: now(),
-      };
-
-      delete payload[prop];
-
-      return new this.IdToken(this.keystore.get(), 'RS256', payload)
-        .then(token => this.client.validateIdToken(token))
-        .then(fail, (error) => {
-          expect(error).to.have.property('message', `missing required JWT property ${prop}`);
-        });
-    });
-  });
-
-  it('verifies iat is a number', function () {
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: 'not a number',
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token))
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 'iat is not a number');
-      });
-  });
-
-  it('verifies iat is in the past', function () {
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now() + 20,
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token))
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 'id_token issued in the future');
-      });
-  });
-
-  it('allows iat skew', function () {
-    this.client.CLOCK_TOLERANCE = 5;
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now() + 5,
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token));
-  });
-
-  it('verifies exp is a number', function () {
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: 'not a nunmber',
-      iat: now(),
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token))
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 'exp is not a number');
-      });
-  });
-
-  it('verifies exp is in the future', function () {
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() - 100,
-      iat: now(),
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token))
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 'id_token expired');
-      });
-  });
-
-  it('allows exp skew', function () {
-    this.client.CLOCK_TOLERANCE = 5;
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() - 4,
-      iat: now(),
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token));
-  });
-
-  it('verifies nbf is a number', function () {
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-      nbf: 'notanumber',
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token))
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 'nbf is not a number');
-      });
-  });
-
-  it('verifies nbf is in the past', function () {
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-      nbf: now() + 20,
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token))
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 'id_token not active yet');
-      });
-  });
-
-  it('allows nbf skew', function () {
-    this.client.CLOCK_TOLERANCE = 5;
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-      nbf: now() + 5,
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token));
-  });
-
-  it('passes when auth_time is within max_age', function () {
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-      auth_time: now() - 200,
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token, null, null, 300));
-  });
-
-  it('verifies auth_time did not exceed max_age', function () {
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-      auth_time: now() - 600,
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token, null, null, 300))
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 'too much time has elapsed since the last End-User authentication');
-      });
-  });
-
-  it('allows auth_time skew', function () {
-    this.client.CLOCK_TOLERANCE = 5;
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-      auth_time: now() - 303,
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token, null, null, 300));
-  });
-
-  it('verifies auth_time is a number', function () {
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-      auth_time: 'foobar',
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token, null, null, 300))
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 'auth_time is not a number');
-      });
-  });
-
-  it('ignores auth_time presence check when require_auth_time is true but null is passed', function () {
-    const client = new this.issuer.Client({
-      client_id: 'with-require_auth_time',
-      require_auth_time: true,
-    });
-
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => client.validateIdToken(token, null, null, null));
-  });
-
-  it('verifies auth_time is present when require_auth_time is true', function () {
-    const client = new this.issuer.Client({
-      client_id: 'with-require_auth_time',
-      require_auth_time: true,
-    });
-
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => client.validateIdToken(token))
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 'missing required JWT property auth_time');
-      });
-  });
-
-  it('verifies auth_time is present when maxAge is passed', function () {
-    const payload = {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    };
-
-    return new this.IdToken(this.keystore.get(), 'RS256', payload)
-      .then(token => this.client.validateIdToken(token, null, null, 300))
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 'missing required JWT property auth_time');
-      });
-  });
-
-  it('passes with the right at_hash', function () {
-    const access_token = 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y'; // eslint-disable-line camelcase, max-len
-    const at_hash = '77QmUPtjPfzWtF2AnpK9RQ'; // eslint-disable-line camelcase
-
-    return new this.IdToken(this.keystore.get(), 'RS256', {
-      at_hash,
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    })
-      .then((token) => {
-        const tokenset = new TokenSet({ access_token, id_token: token });
-        return this.client.validateIdToken(tokenset);
-      });
-  });
-
-  it('validates at_hash presence for implicit flow', function () {
-    const access_token = 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y'; // eslint-disable-line camelcase, max-len
-
-    return new this.IdToken(this.keystore.get(), 'RS256', {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    })
-      .then((token) => {
-      // const tokenset = new TokenSet();
-        return this.client.authorizationCallback(null, { access_token, id_token: token });
-      })
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 'missing required property at_hash');
-      });
-  });
-
-  it('validates c_hash presence for hybrid flow', function () {
-    const code = 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y'; // eslint-disable-line camelcase, max-len
-
-    return new this.IdToken(this.keystore.get(), 'RS256', {
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    })
-      .then((token) => {
-      // const tokenset = new TokenSet();
-        return this.client.authorizationCallback(null, { code, id_token: token });
-      })
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 'missing required property c_hash');
-      });
-  });
-
-  it('validates state presence when s_hash is returned', function () {
-    const s_hash = '77QmUPtjPfzWtF2AnpK9RQ'; // eslint-disable-line camelcase
-
-    return new this.IdToken(this.keystore.get(), 'RS256', {
-      s_hash,
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    })
-      .then((token) => {
-        return this.client.authorizationCallback(null, { id_token: token });
-      })
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 'cannot verify s_hash, state not provided');
-      });
-  });
-
-  it('validates s_hash', function () {
-    const state = 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y'; // eslint-disable-line camelcase, max-len
-    const s_hash = 'foobar'; // eslint-disable-line camelcase
-
-    return new this.IdToken(this.keystore.get(), 'RS256', {
-      s_hash,
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    })
-      .then((token) => {
-        return this.client.authorizationCallback(null, { id_token: token, state }, { state });
-      })
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 's_hash mismatch');
-      });
-  });
-
-  it('passes with the right s_hash', function () {
-    const state = 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y'; // eslint-disable-line camelcase, max-len
-    const s_hash = '77QmUPtjPfzWtF2AnpK9RQ'; // eslint-disable-line camelcase
-
-    return new this.IdToken(this.keystore.get(), 'RS256', {
-      s_hash,
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    })
-      .then((token) => {
-        return this.client.authorizationCallback(null, { id_token: token, state }, { state });
-      });
-  });
-
-  it('fails with the wrong at_hash', function () {
-    const access_token = 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y'; // eslint-disable-line camelcase, max-len
-    const at_hash = 'notvalid77QmUPtjPfzWtF2AnpK9RQ'; // eslint-disable-line camelcase
-
-    return new this.IdToken(this.keystore.get(), 'RS256', {
-      at_hash,
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    })
-      .then((token) => {
-        const tokenset = new TokenSet({ access_token, id_token: token });
-        return this.client.validateIdToken(tokenset);
-      })
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 'at_hash mismatch');
-      });
-  });
-
-  it('passes with the right c_hash', function () {
-    const code = 'Qcb0Orv1zh30vL1MPRsbm-diHiMwcLyZvn1arpZv-Jxf_11jnpEX3Tgfvk'; // eslint-disable-line camelcase, max-len
-    const c_hash = 'LDktKdoQak3Pk0cnXxCltA'; // eslint-disable-line camelcase
-
-    return new this.IdToken(this.keystore.get(), 'RS256', {
-      c_hash,
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    })
-      .then((token) => {
-        const tokenset = new TokenSet({ code, id_token: token });
-        return this.client.validateIdToken(tokenset);
-      });
-  });
-
-  it('fails with the wrong c_hash', function () {
-    const code = 'Qcb0Orv1zh30vL1MPRsbm-diHiMwcLyZvn1arpZv-Jxf_11jnpEX3Tgfvk'; // eslint-disable-line camelcase, max-len
-    const c_hash = 'notvalidLDktKdoQak3Pk0cnXxCltA'; // eslint-disable-line camelcase
-
-    return new this.IdToken(this.keystore.get(), 'RS256', {
-      c_hash,
-      iss: this.issuer.issuer,
-      sub: 'userId',
-      aud: this.client.client_id,
-      exp: now() + 3600,
-      iat: now(),
-    })
-      .then((token) => {
-        const tokenset = new TokenSet({ code, id_token: token });
-        return this.client.validateIdToken(tokenset);
-      })
-      .then(fail, (error) => {
-        expect(error).to.have.property('message', 'c_hash mismatch');
-      });
-  });
-
-  it('fails if tokenset without id_token is passed in', function () {
-    expect(() => {
-      this.client.validateIdToken(new TokenSet({
-        access_token: 'tokenValue',
-        // id_token not
-      }));
-    }).to.throw('id_token not present in TokenSet');
-  });
-});
-
-describe('Distributed and Aggregated Claims', function () {
-  function getJWT(payload, issuer) {
-    const iss = issuer.startsWith('http') ? issuer : `https://${issuer}-iss.example.com`;
-    let keystore;
-    payload.iss = iss;
-
-    if (Registry.has(iss)) {
-      keystore = Registry.get(iss).keystore();
-    } else {
-      const store = jose.JWK.createKeyStore();
-      keystore = store.generate('RSA', 512).then(function () {
-        const i = new Issuer({ issuer: iss, jwks_uri: `${iss}/certs` });
-
-        nock(iss)
-          .persist()
-          .get('/certs')
-          .reply(200, store.toJSON(true));
-
-        return i.keystore();
-      });
-    }
-
-    return keystore.then(function (k) {
-      return jose.JWS.createSign({
-        fields: {
-          alg: 'RS256',
-          typ: 'JWT',
-        },
-        format: 'compact',
-      }, { key: k.get() }).update(JSON.stringify(payload)).final();
-    });
-  }
-
-  describe('Client#fetchDistributedClaims', function () {
-    afterEach(nock.cleanAll);
-    before(function () {
-      const issuer = new Issuer({
-        issuer: 'https://op.example.com',
-        jwks_uri: 'https://op.example.com/jwks',
-        authorization_endpoint: 'https://op.example.com/auth',
-      });
-      this.client = new issuer.Client({
-        client_id: 'identifier',
-      });
-      const store = jose.JWK.createKeyStore();
-
-      return store.generate('RSA', 512).then(() => {
-        nock(issuer.issuer)
-          .get('/jwks')
-          .reply(200, store.toJSON(true));
-
-        return issuer.keystore();
-      });
-    });
-
-    it('just returns userinfo if no distributed claims are to be fetched', function () {
-      const userinfo = {
-        sub: 'userID',
-        _claim_sources: {
-          src1: { JWT: 'not distributed' },
-        },
-      };
-      return this.client.fetchDistributedClaims(userinfo)
-        .then((result) => {
-          expect(result).to.equal(userinfo);
-        });
-    });
-
-    it('fetches the claims from one or more distributed sources', function () {
-      return Promise.all([
-        getJWT({ credit_history: 'foobar' }, 'src1'),
-        getJWT({ email: 'foobar@example.com' }, 'src2'),
-        getJWT({ gender: 'male' }, this.client.issuer.issuer),
-      ]).then((jwts) => {
-        nock('https://src1.example.com')
-          .get('/claims').reply(200, jwts[0]);
-        nock('https://src2.example.com')
-          .get('/claims').reply(200, jwts[1]);
-        nock('https://src3.example.com')
-          .get('/claims').reply(200, [{ alg: 'none' }, { age: 27 }, ''].map((comp) => {
-            if (typeof comp === 'object') {
-              return base64url(JSON.stringify(comp));
-            }
-            return comp;
-          }).join('.'));
-        nock(this.client.issuer.issuer)
-          .get('/claims').reply(200, jwts[2]);
-
-        const userinfo = {
-          sub: 'userID',
-          _claim_names: {
-            credit_history: 'src1',
-            email: 'src2',
-            age: 'src3',
-            gender: 'src4',
-          },
-          _claim_sources: {
-            src1: { endpoint: 'https://src1.example.com/claims', access_token: 'foobar' },
-            src2: { endpoint: 'https://src2.example.com/claims' },
-            src3: { endpoint: 'https://src3.example.com/claims' },
-            src4: { endpoint: `${this.client.issuer.issuer}/claims` },
-          },
-        };
-
-        return this.client.fetchDistributedClaims(userinfo)
-          .then((result) => {
-            expect(result).to.eql({
-              gender: 'male',
-              age: 27,
-              sub: 'userID',
-              credit_history: 'foobar',
-              email: 'foobar@example.com',
-            });
-            expect(result).to.equal(userinfo);
-          });
-      });
-    });
-
-    it('uses access token from provided param if not part of the claims', function () {
-      return getJWT({ credit_history: 'foobar' }, 'src1').then((jwt) => {
-        nock('https://src1.example.com')
-          .matchHeader('authorization', 'Bearer foobar')
-          .get('/claims').reply(200, jwt);
-
-        const userinfo = {
-          sub: 'userID',
-          _claim_names: {
-            credit_history: 'src1',
-          },
-          _claim_sources: {
-            src1: { endpoint: 'https://src1.example.com/claims' },
-          },
-        };
-
-        return this.client.fetchDistributedClaims(userinfo, { src1: 'foobar' })
-          .then((result) => {
-            expect(result).to.eql({
-              sub: 'userID',
-              credit_history: 'foobar',
-            });
-            expect(result).to.equal(userinfo);
-          });
-      });
-    });
-
-    it('validates claims that should be present are', function () {
-      return getJWT({
-        // credit_history: 'foobar',
-      }, 'src1').then((jwt) => {
-        nock('https://src1.example.com')
-          .get('/claims').reply(200, jwt);
-
-        const userinfo = {
-          sub: 'userID',
-          _claim_names: {
-            credit_history: 'src1',
-          },
-          _claim_sources: {
-            src1: { endpoint: 'https://src1.example.com/claims' },
-          },
-        };
-
-        return this.client.fetchDistributedClaims(userinfo)
-          .then(fail, function (error) {
-            expect(error).to.have.property('src', 'src1');
-            expect(error.message).to.equal('expected claim "credit_history" in "src1"');
-          });
-      });
-    });
-
-    it('is rejected with OpenIdConnectError upon oidc error', function () {
-      nock('https://src1.example.com')
-        .get('/claims')
-        .reply(401, {
-          error: 'invalid_token',
-          error_description: 'bad things are happening',
+        it('promises a body', function () {
+          expect(this.auth).to.have.property('body').and.is.an('object');
+          expect(this.auth.body).to.have.property(
+            'client_assertion_type',
+            'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+          );
+          expect(this.auth.body).to.have.property('client_assertion');
         });
 
-      const userinfo = {
-        sub: 'userID',
-        _claim_names: {
-          credit_history: 'src1',
-        },
-        _claim_sources: {
-          src1: { endpoint: 'https://src1.example.com/claims', access_token: 'foobar' },
-        },
-      };
+        it('has a predefined payload properties', function () {
+          const payload = JSON.parse(base64url.decode(this.auth.body.client_assertion.split('.')[1]));
+          expect(payload).to.have.keys(['iat', 'exp', 'jti', 'iss', 'sub', 'aud']);
 
-      return this.client.fetchDistributedClaims(userinfo)
-        .then(fail, function (error) {
-          expect(error.name).to.equal('OpenIdConnectError');
-          expect(error).to.have.property('message', 'invalid_token');
-          expect(error).to.have.property('src', 'src1');
+          expect(payload.iss).to.equal(payload.sub).to.equal('identifier');
+          expect(payload.jti).to.be.a('string');
+          expect(payload.iat).to.be.a('number');
+          expect(payload.exp).to.be.a('number');
+          expect(payload.aud).to.equal('https://rp.example.com/token');
         });
-    });
-  });
 
-  describe('Client#unpackAggregatedClaims', function () {
-    before(function () {
-      const issuer = new Issuer({
-        authorization_endpoint: 'https://op.example.com/auth',
-      });
-      this.client = new issuer.Client({
-        client_id: 'identifier',
-      });
-    });
+        it('has the right header properties', function () {
+          const header = JSON.parse(base64url.decode(this.auth.body.client_assertion.split('.')[0]));
+          expect(header).to.have.keys([
+            'alg', 'typ',
+          ]);
 
-    it('just returns userinfo if no aggregated claims are to be unpacked', function () {
-      const userinfo = {
-        sub: 'userID',
-        _claim_sources: {
-          src1: { endpoint: 'not distributed' },
-        },
-      };
-      return this.client.unpackAggregatedClaims(userinfo)
-        .then((result) => {
-          expect(result).to.equal(userinfo);
+          expect(header.alg).to.equal('HS256');
+          expect(header.typ).to.equal('JWT');
         });
-    });
-
-    it('unpacks the claims from one or more aggregated sources', function () {
-      return Promise.all([
-        getJWT({ credit_history: 'foobar' }, 'src1'),
-        getJWT({ email: 'foobar@example.com' }, 'src2'),
-      ]).then((jwts) => {
-        const userinfo = {
-          sub: 'userID',
-          _claim_names: {
-            credit_history: 'src1',
-            email: 'src2',
-          },
-          _claim_sources: {
-            src1: { JWT: jwts[0] },
-            src2: { JWT: jwts[1] },
-          },
-        };
-
-        return this.client.unpackAggregatedClaims(userinfo)
-          .then((result) => {
-            expect(result).to.eql({
-              sub: 'userID',
-              credit_history: 'foobar',
-              email: 'foobar@example.com',
-            });
-            expect(result).to.equal(userinfo);
-          });
       });
-    });
 
-    it('autodiscovers new issuers', function () {
-      return getJWT({ email_verified: false }, 'cliff').then((cliff) => {
-        const userinfo = {
-          sub: 'userID',
-          _claim_names: {
-            email_verified: 'cliff',
-          },
-          _claim_sources: {
-            cliff: { JWT: cliff },
-          },
-        };
-
-        const iss = 'https://cliff-iss.example.com';
-
-        const discovery = nock(iss)
-          .get('/.well-known/openid-configuration')
-          .reply(200, {
-            issuer: iss,
-            jwks_uri: `${iss}/certs`,
+      context('when private_key_jwt', function () {
+        before(function () {
+          const issuer = new Issuer({
+            token_endpoint: 'https://rp.example.com/token',
+            token_endpoint_auth_signing_alg_values_supported: ['ES256', 'ES384'],
           });
 
-        Registry.delete(iss);
+          const keystore = jose.JWK.createKeyStore();
 
-        return this.client.unpackAggregatedClaims(userinfo)
-          .then((result) => {
-            expect(result).to.eql({
-              sub: 'userID',
-              email_verified: false,
-            });
-            expect(result).to.equal(userinfo);
-            expect(discovery.isDone()).to.be.true;
+          return keystore.generate('EC', 'P-256').then(() => {
+            const client = new issuer.Client({
+              client_id: 'identifier',
+              token_endpoint_auth_method: 'private_key_jwt',
+            }, keystore);
+
+            return client.authFor('token').then((auth) => { this.auth = auth; });
           });
-      });
-    });
-
-    it('validates claims that should be present are', function () {
-      return getJWT({}, 'src1').then((jwt) => {
-        const userinfo = {
-          sub: 'userID',
-          _claim_names: {
-            credit_history: 'src1',
-          },
-          _claim_sources: {
-            src1: { JWT: jwt },
-          },
-        };
-
-        return this.client.unpackAggregatedClaims(userinfo)
-          .then(fail, function (error) {
-            expect(error).to.have.property('src', 'src1');
-            expect(error.message).to.equal('expected claim "credit_history" in "src1"');
-          });
-      });
-    });
-
-    it('rejects discovery errors', function () {
-      return getJWT({ email_verified: false }, 'cliff').then((cliff) => {
-        const userinfo = {
-          sub: 'userID',
-          _claim_names: {
-            email_verified: 'cliff',
-          },
-          _claim_sources: {
-            cliff: { JWT: cliff },
-          },
-        };
-
-        const iss = 'https://cliff-iss.example.com';
-
-        const discovery = nock(iss)
-          .get('/.well-known/openid-configuration')
-          .reply(500, 'Internal Server Error');
-
-        Registry.delete(iss);
-
-        return this.client.unpackAggregatedClaims(userinfo)
-          .then(fail, (error) => {
-            expect(discovery.isDone()).to.be.true;
-            expect(error.name).to.equal('HTTPError');
-            expect(error.src).to.equal('cliff');
-          });
-      });
-    });
-
-    it('rejects JWT errors', function () {
-      const userinfo = {
-        sub: 'userID',
-        _claim_names: {
-          email_verified: 'src1',
-        },
-        _claim_sources: {
-          src1: { JWT: 'not.a.jwt' },
-        },
-      };
-
-      return this.client.unpackAggregatedClaims(userinfo)
-        .then(fail, (error) => {
-          expect(error.src).to.equal('src1');
         });
+
+        it('promises a body', function () {
+          expect(this.auth).to.have.property('body').and.is.an('object');
+          expect(this.auth.body).to.have.property(
+            'client_assertion_type',
+            'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'
+          );
+          expect(this.auth.body).to.have.property('client_assertion');
+        });
+
+        it('has a predefined payload properties', function () {
+          const payload = JSON.parse(base64url.decode(this.auth.body.client_assertion.split('.')[1]));
+          expect(payload).to.have.keys(['iat', 'exp', 'jti', 'iss', 'sub', 'aud']);
+
+          expect(payload.iss).to.equal(payload.sub).to.equal('identifier');
+          expect(payload.jti).to.be.a('string');
+          expect(payload.iat).to.be.a('number');
+          expect(payload.exp).to.be.a('number');
+          expect(payload.aud).to.equal('https://rp.example.com/token');
+        });
+
+        it('has the right header properties', function () {
+          const header = JSON.parse(base64url.decode(this.auth.body.client_assertion.split('.')[0]));
+          expect(header).to.have.keys([
+            'alg', 'typ', 'kid',
+          ]);
+
+          expect(header.alg).to.equal('ES256');
+          expect(header.typ).to.equal('JWT');
+          expect(header.kid).to.be.ok;
+        });
+      });
     });
   });
 
-
-  /* eslint-disable max-len */
-  describe('signed and encrypted responses', function () {
-    before(function () {
-      return jose.JWK.asKeyStore({
-        keys: [
-          {
-            kty: 'EC',
-            kid: 'L3qrG8dSNYv6F-Hvv-qTdp_EkmgwjQX76DHmDZCoa4Q',
-            crv: 'P-256',
-            x: 'PDsKZY9JxlbrE-hHce_e_H7yjWgxftRIowdW9qxBqNQ',
-            y: 'EAmrpjkbBkuBZAD2kvuL5mOXgdK_8t1t93yKGGHq_Y4',
-            d: '59efvkfuCuVLW9Y4xvLvUyjARwgnSgwTLRc0UGpewLA',
-          },
-        ],
-      }).then((keystore) => { this.keystore = keystore; });
+  describe('Client#validateIdToken', function () {
+    afterEach(function () {
+      if (this.client) this.client.CLOCK_TOLERANCE = 0;
     });
 
-    it('handles signed and encrypted id_tokens from implicit and code responses (test by hybrid)', function () {
-      const time = new Date(1473076413242);
-      timekeeper.freeze(time);
-      const issuer = new Issuer({
-        issuer: 'https://guarded-cliffs-8635.herokuapp.com/op',
-        token_endpoint: 'https://op.example.com/token',
-        userinfo_endpoint: 'https://op.example.com/me',
-      });
-
-      nock('https://op.example.com')
-        .post('/token')
-        .reply(200, {
-          access_token: 'eyJraW5kIjoiQWNjZXNzVG9rZW4iLCJqdGkiOiJlMDk5YTI1ZC02MzA0LTQwMGItOTdhYi1hOTJhMzMzOTBlODgiLCJpYXQiOjE0NzMwNzY0MTMsImV4cCI6MTQ3MzA4MzYxMywiaXNzIjoiaHR0cHM6Ly9ndWFyZGVkLWNsaWZmcy04NjM1Lmhlcm9rdWFwcC5jb20vb3AifQ.p_r4KvAu6lEY6JpGmRIGCkRRrovGeJcDfOw3O_gFkPRaY7bcJjNDUPlfY7_nyp3bWyqtveq55ozTZuddUL01KET7bKgxMq-dQ2SxGBvgN3KtHIRBud7Bw8Ax98YkiBKJJXC8xF00VZkkX-ZcUyXptPkUpBm0zeN6jmWmyFX-2QrbclLS8ZEK2Poc_y5PdNAtCCOTBfnq6roxzVQ5lM_aMQaSuPVd-Og6E_jBE6OE9oB4ikFa4S7EvZvFVDpGMLtUjxOazTURbqWY6OnuhuAiP6WZc1FxfQod462IqPERzl2qVJH9qQNr-iLuVLt_bzauHg33v1koTrdfETyoRAZH5w',
-          expires_at: 1473083613,
-          id_token: 'eyJhbGciOiJFQ0RILUVTK0ExMjhLVyIsImtpZCI6IkwzcXJHOGRTTll2NkYtSHZ2LXFUZHBfRWttZ3dqUVg3NkRIbURaQ29hNFEiLCJlcGsiOnsia3R5IjoiRUMiLCJjcnYiOiJQLTI1NiIsIngiOiJJVXRTWnZOVzBubUNmT2Nwek5JSnBBS29FbGpOVkZyUlJGa2pDT3plYnlRIiwieSI6IjNEOXZ1V2VJNEdVajZWczZ4ZUJlMVZRM3dHQnhkU3BnTGdYcGZPUThmeEkifSwiZW5jIjoiQTEyOENCQy1IUzI1NiIsImN0eSI6IkpXVCJ9.DVIPxvxnQASDiair_I_6e4M1Y8yMdzIneHMPq_LlBjo8QAiwjMQ1Uw.gdLKThNa_DcFmPGBmzOBkg.TQZ4qpEchLx9nnNIfG_N8d3sL-S-p1vpWbA3MnK68U60kX7i29s33fxhH3w5MQhZbgxjntrbRdE9wFsBzclr8hfwazBTpi6D5Ignug0xCZQYw7HBDrkq63-7PQQa2-rivTtxQxAWUZj7dnNE4Ixo9qaBkHod1EPf5xameCDzgrRa2oi2ISEE6ncQrvc7jnANeBQj0Q2OLmo9L7EIVQbEKejGfZ_0p5HiXmgFMpLbkLFwYhTdpiSUCkZlcym-e2tgbzHJmtF85cx2-yDwDNGLvY8y5ytW79_k_ckbHKVTjf_jRMagqM7Mt6TQ1fhm9T7FZ4q-96L0ItGb12jar2Aw6VWP1DAwUMZ1jA8mmllsWu-y7qc9Ert5rlJ7osZzMOgaNfX1sf5Xa7aOHysC-tVxknIPtxAamVJ7REGxmii-FO6En4zgJMt1PLUoTTK4tIpIX06VWDKI-dQzn46ple9xeuzCUvpvap823Xl9ONcVj4AF-YmHU-UkT96gx_6Owqcwm6synOh1l2O9rRi9jJnCg6egTqn1MHaVhTYaVhKQQUpE-voAoXoaJDoLQX2fC6IjF5H2xnc_1k61wGBJkX_7zqagNYGJyoluiQr5EGkB8pxANJVHNIW37ezJEIjnix5h_Fwzh_XElGzVsKeB-ih9X6ECSVJ1VIPopN5t38kGa8lQuM7vLr0i__cvYP8TgyE94nllEl-5f0gHOUQrpcUEqpsZYRBGcW_m8iU3nuvD0Em6nCvvzPUvlmCRyANQbs3A.H9oTPRc3ahVDUuYj3C9-gQ',
-          refresh_token: 'eyJraW5kIjoiUmVmcmVzaFRva2VuIiwianRpIjoiMzhmZTY1NmItNjYyMC00MzdiLWJmY2YtZTRjNzRhZTRiNjMzIiwibm9uY2UiOiJjNjQ1ZmZmYTQwMDc1NTMyZWYyOWEyZWE2MjdjZmEzNyIsImlhdCI6MTQ3MzA3NjQxMywiZXhwIjoxNDc1NjY4NDEzLCJpc3MiOiJodHRwczovL2d1YXJkZWQtY2xpZmZzLTg2MzUuaGVyb2t1YXBwLmNvbS9vcCJ9.hySAknc2L2ngSoTiRxUTJLOUxKmyRTUzLsRlGKip4OXNYXre9QEDH8z9c8NKBHdnRbBxg8Jo45cZbDb-5bZ6mt5noDmT42xtsCOiN25Is9SsRSzVarIDiwyqXVlTojh5XuKPulK4Ji6vp2jYUZNoVnlsA7G96cuHWVAqZd5e8GBb9YlUNZ5zSX6aggFgTGDJs46O42_g4JULB8cAb9MZAzcZOORGpmRIPpSKAZFgT2_5yW-yqh0f66JaAQUtW9TKoAsdttV4NnivzJYeyR0hlgEeKzo9zNuTkJedXbjRAIP6ybk9ITcZveuJ11CFsyHZcNd_0tZuiAlvUpJIeHK0aA',
-          token_type: 'Bearer',
-        });
-
-      const client = new issuer.Client({
-        client_id: '4e87dde4-ddd3-4c21-aef9-2f2f6bab43ca',
-        client_secret: 'GfsT479VMy5ZZZPquadPbN3wKzaFGYo1CTkb0IFFzDNODLEAuC2GUV3QsTye3xNQ',
-        id_token_encrypted_response_alg: 'ECDH-ES+A128KW',
-        id_token_encrypted_response_enc: 'A128CBC-HS256',
-        id_token_signed_response_alg: 'HS256',
-      }, this.keystore);
-
-      return client.authorizationCallback('http://oidc-client.dev/cb', {
-        code: 'eyJraW5kIjoiQXV0aG9yaXphdGlvbkNvZGUiLCJqdGkiOiI3YzM5NzQyZC0yMGUyLTQ3YjEtYmM1MC1lN2VlYzhmN2IzNmYiLCJub25jZSI6ImM2NDVmZmZhNDAwNzU1MzJlZjI5YTJlYTYyN2NmYTM3IiwiaWF0IjoxNDczMDc2NDEyLCJleHAiOjE0NzMwNzcwMTIsImlzcyI6Imh0dHBzOi8vZ3VhcmRlZC1jbGlmZnMtODYzNS5oZXJva3VhcHAuY29tL29wIn0.jgUnZUBmsceb1cpqlsmiCOQ40Zx4JTRffGN_bAgYT4rLcEv3wOlzMSoVmU1cYkDbi-jjNAqkBjqxDWHcRJnQR4BAYOdyDVcGWD_aLkqGhUOCJHn_lwWqEKtSTgh-zXiqVIVC5NTA2BdhEfHhb-jnMQNrKkL2QNXOFvT9s6khZozOMXy-mUdfNfdSFHrcpFkFyGAUpezI9QmwToMB6KwoRHDYb2jcLBXdA5JLAnHw8lpz9yUaVQv7s97wY7Xgtt2zNFwQxiJWytYNHaJxQnOZje0_TvDjrZSA9IYKuKU1Q7f7-EBfQfFSGcsFK2NtGho3mNBEUDD2B8Qv1ipv50oU6Q',
-        id_token: 'eyJhbGciOiJFQ0RILUVTK0ExMjhLVyIsImtpZCI6IkwzcXJHOGRTTll2NkYtSHZ2LXFUZHBfRWttZ3dqUVg3NkRIbURaQ29hNFEiLCJlcGsiOnsia3R5IjoiRUMiLCJjcnYiOiJQLTI1NiIsIngiOiJyellvRzJXeTZtSWhIZ01pMk1SNmd0alpPbG40SzZnSVExVU0yS0tOaFBjIiwieSI6IjF0TmNVZTJSNHBPM2NRZUVtQTF6Z1AzNVdXV19xSUNCMDY3WHFZZGJPSXMifSwiZW5jIjoiQTEyOENCQy1IUzI1NiIsImN0eSI6IkpXVCJ9.yMWht5iTHhr6EKd-Dy7vw_qkRnuh7RtFpLWfs0TOQ6IAIF6K5ieUKw.-wtcftFYgbs7Rj1g-zKaXw.s8BposTeAeUdqSIjKKYADk5THIP33_nLNmGcScQ94vHApM6lUeuMPNdtjGIRJfLoBnIjr0JLYUX_oB-8nXxDCgV19alT0xzc9bKMbb6FR7gHS4R6nVUFAumtpl50iwFs-xGIcVsrr76lQJv5m139EqSeCXse2OY8Q0YyBJgEb_hL4kDXpqxwAd-VqyQzyrAXd_pIlVUnydZ6BC4ZPvbN7RJPR8z1EN46GEYknweuyhT_5tD4FkcngJPRoXJ_KnEr9Q7qbIbCWMmn6bBO59uvv-MXCM2PXIaRNTwZ2_Vp0pB6LkmVC6kHcsotBBGzc-TH_5t87t4JhB1XtTyfl_Nn1YCETdVh8iJUTk_F6ntokka0PTvjXfVQZkqZHT6j6PqZzqMngHNh2lxaFRod9DxT00QEDHXoBGaMDIjBMAt0vI4vIeXqxIMtqJ3i8FMm9bociXo5kpRDgBgmTllJ8O7GDw5q0M7ZIg5dRr0aph8TeXDImwvbPhk32T6tXJVg1i8N7dTICVc0BTitp4cIw2TFXoiR3eSyLusrJ4H3qe-SNJUoq0sPBwzg1tEiDbsDaHhxiwLRu1rcyOcXEqT5Ry0bJM09I_ypEAX9JoA_5NbiY1PVx7rMDxDUreEBW_1xEG8rgXkAmVHHZWLUiEmxQ4RCnityGKIEbG7OFjOOd6CXuznnBEDV-F120bcDCaIClwYI.yFz2AdC2eJ7GX-9gYUMy8Q',
-        state: '36853f4ea7c9d26f4b0b95f126afe6a2',
-        session_state: 'foobar.foo',
-      }, { state: '36853f4ea7c9d26f4b0b95f126afe6a2', nonce: 'c645fffa40075532ef29a2ea627cfa37' });
-    });
-
-    it('handles signed and encrypted id_tokens from refresh grant', function () {
-      const time = new Date(1473076413242);
-      timekeeper.freeze(time);
-      const issuer = new Issuer({
-        issuer: 'https://guarded-cliffs-8635.herokuapp.com/op',
-        token_endpoint: 'https://op.example.com/token',
-      });
-
-      nock('https://op.example.com')
-        .post('/token')
-        .reply(200, {
-          access_token: 'eyJraW5kIjoiQWNjZXNzVG9rZW4iLCJqdGkiOiJlMDk5YTI1ZC02MzA0LTQwMGItOTdhYi1hOTJhMzMzOTBlODgiLCJpYXQiOjE0NzMwNzY0MTMsImV4cCI6MTQ3MzA4MzYxMywiaXNzIjoiaHR0cHM6Ly9ndWFyZGVkLWNsaWZmcy04NjM1Lmhlcm9rdWFwcC5jb20vb3AifQ.p_r4KvAu6lEY6JpGmRIGCkRRrovGeJcDfOw3O_gFkPRaY7bcJjNDUPlfY7_nyp3bWyqtveq55ozTZuddUL01KET7bKgxMq-dQ2SxGBvgN3KtHIRBud7Bw8Ax98YkiBKJJXC8xF00VZkkX-ZcUyXptPkUpBm0zeN6jmWmyFX-2QrbclLS8ZEK2Poc_y5PdNAtCCOTBfnq6roxzVQ5lM_aMQaSuPVd-Og6E_jBE6OE9oB4ikFa4S7EvZvFVDpGMLtUjxOazTURbqWY6OnuhuAiP6WZc1FxfQod462IqPERzl2qVJH9qQNr-iLuVLt_bzauHg33v1koTrdfETyoRAZH5w',
-          expires_at: 1473083613,
-          id_token: 'eyJhbGciOiJFQ0RILUVTK0ExMjhLVyIsImtpZCI6IkwzcXJHOGRTTll2NkYtSHZ2LXFUZHBfRWttZ3dqUVg3NkRIbURaQ29hNFEiLCJlcGsiOnsia3R5IjoiRUMiLCJjcnYiOiJQLTI1NiIsIngiOiJJVXRTWnZOVzBubUNmT2Nwek5JSnBBS29FbGpOVkZyUlJGa2pDT3plYnlRIiwieSI6IjNEOXZ1V2VJNEdVajZWczZ4ZUJlMVZRM3dHQnhkU3BnTGdYcGZPUThmeEkifSwiZW5jIjoiQTEyOENCQy1IUzI1NiIsImN0eSI6IkpXVCJ9.DVIPxvxnQASDiair_I_6e4M1Y8yMdzIneHMPq_LlBjo8QAiwjMQ1Uw.gdLKThNa_DcFmPGBmzOBkg.TQZ4qpEchLx9nnNIfG_N8d3sL-S-p1vpWbA3MnK68U60kX7i29s33fxhH3w5MQhZbgxjntrbRdE9wFsBzclr8hfwazBTpi6D5Ignug0xCZQYw7HBDrkq63-7PQQa2-rivTtxQxAWUZj7dnNE4Ixo9qaBkHod1EPf5xameCDzgrRa2oi2ISEE6ncQrvc7jnANeBQj0Q2OLmo9L7EIVQbEKejGfZ_0p5HiXmgFMpLbkLFwYhTdpiSUCkZlcym-e2tgbzHJmtF85cx2-yDwDNGLvY8y5ytW79_k_ckbHKVTjf_jRMagqM7Mt6TQ1fhm9T7FZ4q-96L0ItGb12jar2Aw6VWP1DAwUMZ1jA8mmllsWu-y7qc9Ert5rlJ7osZzMOgaNfX1sf5Xa7aOHysC-tVxknIPtxAamVJ7REGxmii-FO6En4zgJMt1PLUoTTK4tIpIX06VWDKI-dQzn46ple9xeuzCUvpvap823Xl9ONcVj4AF-YmHU-UkT96gx_6Owqcwm6synOh1l2O9rRi9jJnCg6egTqn1MHaVhTYaVhKQQUpE-voAoXoaJDoLQX2fC6IjF5H2xnc_1k61wGBJkX_7zqagNYGJyoluiQr5EGkB8pxANJVHNIW37ezJEIjnix5h_Fwzh_XElGzVsKeB-ih9X6ECSVJ1VIPopN5t38kGa8lQuM7vLr0i__cvYP8TgyE94nllEl-5f0gHOUQrpcUEqpsZYRBGcW_m8iU3nuvD0Em6nCvvzPUvlmCRyANQbs3A.H9oTPRc3ahVDUuYj3C9-gQ',
-          refresh_token: 'eyJraW5kIjoiUmVmcmVzaFRva2VuIiwianRpIjoiMzhmZTY1NmItNjYyMC00MzdiLWJmY2YtZTRjNzRhZTRiNjMzIiwibm9uY2UiOiJjNjQ1ZmZmYTQwMDc1NTMyZWYyOWEyZWE2MjdjZmEzNyIsImlhdCI6MTQ3MzA3NjQxMywiZXhwIjoxNDc1NjY4NDEzLCJpc3MiOiJodHRwczovL2d1YXJkZWQtY2xpZmZzLTg2MzUuaGVyb2t1YXBwLmNvbS9vcCJ9.hySAknc2L2ngSoTiRxUTJLOUxKmyRTUzLsRlGKip4OXNYXre9QEDH8z9c8NKBHdnRbBxg8Jo45cZbDb-5bZ6mt5noDmT42xtsCOiN25Is9SsRSzVarIDiwyqXVlTojh5XuKPulK4Ji6vp2jYUZNoVnlsA7G96cuHWVAqZd5e8GBb9YlUNZ5zSX6aggFgTGDJs46O42_g4JULB8cAb9MZAzcZOORGpmRIPpSKAZFgT2_5yW-yqh0f66JaAQUtW9TKoAsdttV4NnivzJYeyR0hlgEeKzo9zNuTkJedXbjRAIP6ybk9ITcZveuJ11CFsyHZcNd_0tZuiAlvUpJIeHK0aA',
-          token_type: 'Bearer',
-        });
-
-      const client = new issuer.Client({
-        client_id: '4e87dde4-ddd3-4c21-aef9-2f2f6bab43ca',
-        client_secret: 'GfsT479VMy5ZZZPquadPbN3wKzaFGYo1CTkb0IFFzDNODLEAuC2GUV3QsTye3xNQ',
-        id_token_encrypted_response_alg: 'ECDH-ES+A128KW',
-        id_token_encrypted_response_enc: 'A128CBC-HS256',
-        id_token_signed_response_alg: 'HS256',
-      }, this.keystore);
-
-      return client.refresh('http://oidc-client.dev/cb', new TokenSet({
-        refresh_token: 'eyJraW5kIjoiUmVmcmVzaFRva2VuIiwianRpIjoiMzhmZTY1NmItNjYyMC00MzdiLWJmY2YtZTRjNzRhZTRiNjMzIiwibm9uY2UiOiJjNjQ1ZmZmYTQwMDc1NTMyZWYyOWEyZWE2MjdjZmEzNyIsImlhdCI6MTQ3MzA3NjQxMywiZXhwIjoxNDc1NjY4NDEzLCJpc3MiOiJodHRwczovL2d1YXJkZWQtY2xpZmZzLTg2MzUuaGVyb2t1YXBwLmNvbS9vcCJ9.hySAknc2L2ngSoTiRxUTJLOUxKmyRTUzLsRlGKip4OXNYXre9QEDH8z9c8NKBHdnRbBxg8Jo45cZbDb-5bZ6mt5noDmT42xtsCOiN25Is9SsRSzVarIDiwyqXVlTojh5XuKPulK4Ji6vp2jYUZNoVnlsA7G96cuHWVAqZd5e8GBb9YlUNZ5zSX6aggFgTGDJs46O42_g4JULB8cAb9MZAzcZOORGpmRIPpSKAZFgT2_5yW-yqh0f66JaAQUtW9TKoAsdttV4NnivzJYeyR0hlgEeKzo9zNuTkJedXbjRAIP6ybk9ITcZveuJ11CFsyHZcNd_0tZuiAlvUpJIeHK0aA',
-      }), { nonce: null });
-    });
-
-    it('handles encrypted but not signed responses too', function () {
-      const time = new Date(1473076413242);
-      timekeeper.freeze(time);
-      const issuer = new Issuer({
-        issuer: 'https://guarded-cliffs-8635.herokuapp.com/op',
-        userinfo_endpoint: 'https://op.example.com/me',
-      });
-
-      nock('https://op.example.com')
-        .get('/me')
-        .reply(200, 'eyJhbGciOiJFQ0RILUVTK0ExMjhLVyIsImtpZCI6IkwzcXJHOGRTTll2NkYtSHZ2LXFUZHBfRWttZ3dqUVg3NkRIbURaQ29hNFEiLCJlcGsiOnsia3R5IjoiRUMiLCJjcnYiOiJQLTI1NiIsIngiOiI4SUpmUTJQU3JBTFlqd0oyd3ZXWGZoTDJGRmgyekRxVUU1dHpZRVYybTVJIiwieSI6IjhfRkFIdzVzZmJ2c1drQ0ZRLW1mN2I3VVFYempWS0UyNWE3LXVKbEZoZUkifSwiZW5jIjoiQTEyOENCQy1IUzI1NiIsImN0eSI6IkpXVCJ9.KnATIoEGwPKAJHyKAKGVjmeuu4PmsKjXydV047kqzUzXFHPes60zSg.D50tt0pN1HygTtOs5Hu26Q.RWmwnKdALaafgNy3X9Zvvnb27XvJiDqFKQ9kqIOFBV-MtG0Q5dQaB5v6ldaExWTyugGAtP_s1LS8zlX-E9V5eHeXmJkYn9qIQbjJ9eHdHLk.uypPS5AVSBN9XNGqeVrzuQ', {
-          'content-type': 'application/jwt; charset=utf-8',
-        });
-
-      const client = new issuer.Client({
-        client_id: 'f21d5d1d-1c3f-4905-8ff1-5f553a2090b1',
-        userinfo_encrypted_response_alg: 'ECDH-ES+A128KW',
-        userinfo_encrypted_response_enc: 'A128CBC-HS256',
-      }, this.keystore);
-
-      return client.userinfo('accesstoken').then((userinfo) => {
-        expect(userinfo).to.eql({
-          email: 'johndoe@example.com',
-          sub: '0aa66887-8c86-4f3b-b521-5a00e01799ca',
-        });
-      });
-    });
-
-    it('handles symmetric encryption', function () {
-      const time = new Date(1474477036849);
-      timekeeper.freeze(time);
-      const issuer = new Issuer({ issuer: 'http://localhost:3000/op' });
-
-      const client = new issuer.Client({
-        client_id: '0d9413a4-61c1-4b2b-8d84-a82464c1556c',
-        client_secret: 'l73jho9z9mL0GAomiQwbw08ARqro2tJ4E4qhJ+PZhNQoU6G6D23UDF91L9VR7iJ4',
-        id_token_encrypted_response_alg: 'A128KW',
-        id_token_encrypted_response_enc: 'A128CBC-HS256',
-        id_token_signed_response_alg: 'HS256',
-      });
-
-      return client.authorizationCallback('http://oidc-client.dev/cb', {
-        id_token: 'eyJhbGciOiJBMTI4S1ciLCJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiY3R5IjoiSldUIn0.mAnRgJuG85tPgVMlFVcDnJF4aX63y0ZaqnRvv5EB32kp1kaJ17Oedg.fIf22AkMIaL-BylAMNSw7Q.aLMcch8U-Wx-6Y9xPti5b-H63AthqlCihBLCBZvRYd476HyCAzvuGMGzvHOuPFgFaAsxzOWkWNULOtQB2TiE2wLwCatrU2yUgaUisfXUKq1Lw0AFXyZmqcot-RNlf8hucoFHp7e9AoflKGibHEie80xHgw04jxTT7B0Y_OhpSng1cWBd3AU7UwCFKOngUugdBZ2dOmZ2zyq1oYY5FDmhm4hfB0a05s7jwImsXLsYK1LLw7wBjSzKBCJZwR055T0NbsadK1ze3rbwmx9fEruANSDSwUxsapbv1nvFPGvf03Da7FPOztVaLEraRkhXQIq1oAV2sXgKS2nD8nsEsAzJqt1iARmkj0udwmdhpHdnpRBtFJNEAAfEJf8B3ZbwvD7k0HaWEupLIdnY0nqiYKfjDUB9oFAjFOTnjrjqMt4fI73Axh5BcG6n-wCYxF3zGPGLhV_wR8usG_JKIZIeyaVik7isGBEPnFW98RX1Te5TUDLG-J84QrwauTpMkv99h_fkuJI-m1TfOTDAN2mZcTpQyuCZFDDjaYArhSMTUHgx2XSffPS8QmV8LqWMgwodyfxbGEvhbr_jpECXMV5J_ZXuKA.tCM9AdCCGHwLHXxzec7wtg',
-      }, { nonce: '9cda9a61a2b01b31aa0b31d3c33631a1' });
-    });
-  });
-
-  describe('#callbackParams', function () {
-    before(function () {
-      const issuer = new Issuer({ issuer: 'http://localhost:3000/op' });
-      this.client = new issuer.Client({ client_id: 'client_id' });
-    });
-
-    before(function () {
-      this.origIncomingMessage = stdhttp.IncomingMessage;
-      stdhttp.IncomingMessage = MockRequest;
-    });
-
-    after(function () {
-      stdhttp.IncomingMessage = this.origIncomingMessage;
-    });
-
-    it('returns query params from full uri', function () {
-      expect(this.client.callbackParams('http://oidc-client.dev/cb?code=code')).to.eql({ code: 'code' });
-    });
-
-    it('returns query params from node request uri', function () {
-      expect(this.client.callbackParams('/cb?code=code')).to.eql({ code: 'code' });
-    });
-
-    it('works with IncomingMessage (GET + query)', function () {
-      const req = new MockRequest('GET', '/cb?code=code');
-      expect(this.client.callbackParams(req)).to.eql({ code: 'code' });
-    });
-
-    it('works with IncomingMessage (POST + pre-parsed string)', function () {
-      const req = new MockRequest('POST', '/cb', {
-        body: 'code=code',
-      });
-      expect(this.client.callbackParams(req)).to.eql({ code: 'code' });
-    });
-
-    it('works with IncomingMessage (POST + pre-parsed object)', function () {
-      const req = new MockRequest('POST', '/cb', {
-        body: { code: 'code' },
-      });
-      expect(this.client.callbackParams(req)).to.eql({ code: 'code' });
-    });
-
-    it('works with IncomingMessage (POST + pre-parsed buffer)', function () {
-      const req = new MockRequest('POST', '/cb', {
-        body: new Buffer('code=code'),
-      });
-      expect(this.client.callbackParams(req)).to.eql({ code: 'code' });
-    });
-
-    it('rejects nonbody parsed POSTs', function () {
-      const req = new MockRequest('POST', '/cb');
-      expect(() => {
-        this.client.callbackParams(req);
-      }).to.throw('incoming message body missing, include a body parser prior to this call');
-    });
-
-    it('rejects non-object,buffer,string parsed bodies', function () {
-      const req = new MockRequest('POST', '/cb', { body: true });
-      expect(() => {
-        this.client.callbackParams(req);
-      }).to.throw('invalid IncomingMessage body object');
-    });
-
-    it('rejects IncomingMessage other than GET, POST', function () {
-      const req = new MockRequest('PUT', '/cb', {
-        body: { code: 'code' },
-      });
-      expect(() => {
-        this.client.callbackParams(req);
-      }).to.throw('invalid IncomingMessage method');
-    });
-
-    it('fails for other than strings or IncomingMessage', function () {
-      expect(() => {
-        this.client.callbackParams({});
-      }).to.throw('#callbackParams only accepts string urls, http.IncomingMessage or a lookalike');
-      expect(() => {
-        this.client.callbackParams(true);
-      }).to.throw('#callbackParams only accepts string urls, http.IncomingMessage or a lookalike');
-      expect(() => {
-        this.client.callbackParams([]);
-      }).to.throw('#callbackParams only accepts string urls, http.IncomingMessage or a lookalike');
-    });
-  });
-
-  describe('#requestObject', function () {
     before(function () {
       this.keystore = jose.JWK.createKeyStore();
       return this.keystore.generate('RSA', 512);
@@ -2294,96 +1018,1378 @@ describe('Distributed and Aggregated Claims', function () {
         issuer: 'https://op.example.com',
         jwks_uri: 'https://op.example.com/certs',
       });
+      this.client = new this.issuer.Client({
+        client_id: 'identifier',
+        client_secret: 'its gotta be a long secret and i mean at least 32 characters',
+      });
+
+      this.IdToken = class IdToken {
+        constructor(key, alg, payload) {
+          return jose.JWS.createSign({
+            fields: { alg, typ: 'JWT' },
+            format: 'compact',
+          }, { key, reference: !alg.startsWith('HS') }).update(JSON.stringify(payload)).final();
+        }
+      };
     });
 
     before(function () {
       nock('https://op.example.com')
+        .persist()
         .get('/certs')
         .reply(200, this.keystore.toJSON());
-
-      return this.issuer.key();
     });
 
     after(nock.cleanAll);
 
-    it('sign alg=none', function () {
-      const client = new this.issuer.Client({ client_id: 'client_id', request_object_signing_alg: 'none' });
+    it('validates the id token and fulfills with input value (when string)', function () {
+      return new this.IdToken(this.keystore.get(), 'RS256', {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      })
+        .then(token => this.client.validateIdToken(token).then((validated) => {
+          expect(validated).to.equal(token);
+        }));
+    });
 
-      return client.requestObject({ state: 'foobar' })
-        .then((signed) => {
-          const parts = signed.split('.');
-          expect(JSON.parse(base64url.decode(parts[0]))).to.eql({ alg: 'none', typ: 'JWT' });
-          expect(JSON.parse(base64url.decode(parts[1]))).to.eql({
-            iss: 'client_id', client_id: 'client_id', aud: 'https://op.example.com', state: 'foobar',
+    it('validates the id token and fulfills with input value (when TokenSet)', function () {
+      return new this.IdToken(this.keystore.get(), 'RS256', {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      })
+        .then((token) => {
+          const tokenset = new TokenSet({ id_token: token });
+          return this.client.validateIdToken(tokenset).then((validated) => {
+            expect(validated).to.equal(tokenset);
           });
-          expect(parts[2]).to.equal('');
         });
     });
 
-    it('sign alg=HSxxx', function () {
-      const client = new this.issuer.Client({ client_id: 'client_id', request_object_signing_alg: 'HS256', client_secret: 'atleast32byteslongforHS256mmkay?' });
+    it('validates the id token signature (when string)', function () {
+      return new this.IdToken(this.keystore.get(), 'RS256', {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      })
+        .then(token => this.client.validateIdToken(token.slice(0, -1)).then(fail, (err) => {
+          expect(err.message).to.equal('invalid signature');
+        }));
+    });
 
-      return client.requestObject({ state: 'foobar' })
-        .then((signed) => {
-          const parts = signed.split('.');
-          expect(JSON.parse(base64url.decode(parts[0]))).to.eql({ alg: 'HS256', typ: 'JWT' });
-          expect(JSON.parse(base64url.decode(parts[1]))).to.eql({
-            iss: 'client_id', client_id: 'client_id', aud: 'https://op.example.com', state: 'foobar',
+    it('validates the id token signature (when TokenSet)', function () {
+      return new this.IdToken(this.keystore.get(), 'RS256', {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      })
+        .then((token) => {
+          const tokenset = new TokenSet({ id_token: token.slice(0, -1) });
+          return this.client.validateIdToken(tokenset).then(fail, (err) => {
+            expect(err.message).to.equal('invalid signature');
           });
-          expect(parts[2].length).to.be.ok;
         });
     });
 
-    it('sign alg=RSxxx', function () {
-      const client = new this.issuer.Client({ client_id: 'client_id', request_object_signing_alg: 'RS256' }, this.keystore);
-
-      return client.requestObject({ state: 'foobar' })
-        .then((signed) => {
-          const parts = signed.split('.');
-          expect(JSON.parse(base64url.decode(parts[0]))).to.contain({ alg: 'RS256', typ: 'JWT' }).and.have.property('kid');
-          expect(JSON.parse(base64url.decode(parts[1]))).to.eql({
-            iss: 'client_id', client_id: 'client_id', aud: 'https://op.example.com', state: 'foobar',
-          });
-          expect(parts[2].length).to.be.ok;
-        });
-    });
-
-    it('encrypts for issuer using issuer\'s public key', function () {
-      const client = new this.issuer.Client({ client_id: 'client_id', request_object_encryption_alg: 'RSA1_5', request_object_encryption_enc: 'A128CBC-HS256' });
-
-      return client.requestObject({ state: 'foobar' })
-        .then((encrypted) => {
-          const parts = encrypted.split('.');
-          expect(JSON.parse(base64url.decode(parts[0]))).to.contain({ alg: 'RSA1_5', enc: 'A128CBC-HS256', cty: 'JWT' }).and.have.property('kid');
-        });
-    });
-
-    it('encrypts for issuer using pre-shared client_secret (PBES2)', function () {
+    it('validates the id token and fulfills with input value (when signed by secret)', function () {
       const client = new this.issuer.Client({
-        client_id: 'client_id',
-        client_secret: 'GfsT479VMy5ZZZPquadPbN3wKzaFGYo1CTkb0IFFzDNODLEAuC2GUV3QsTye3xNQ',
-        request_object_encryption_alg: 'PBES2-HS256+A128KW',
+        client_id: 'hs256-client',
+        client_secret: 'its gotta be a long secret and i mean at least 32 characters',
+        id_token_signed_response_alg: 'HS256',
       });
 
-      return client.requestObject({ state: 'foobar' })
-        .then((encrypted) => {
-          const parts = encrypted.split('.');
-          expect(JSON.parse(base64url.decode(parts[0]))).to.contain({ alg: 'PBES2-HS256+A128KW', enc: 'A128CBC-HS256', cty: 'JWT' }).and.not.have.property('kid');
+      return client.joseSecret().then((key) => {
+        return new this.IdToken(key, 'HS256', {
+          iss: this.issuer.issuer,
+          sub: 'userId',
+          aud: client.client_id,
+          exp: now() + 3600,
+          iat: now(),
+        })
+          .then((token) => {
+            const tokenset = new TokenSet({ id_token: token });
+            return client.validateIdToken(tokenset).then((validated) => {
+              expect(validated).to.equal(tokenset);
+            });
+          });
+      });
+    });
+
+    it('can be also used for userinfo response validation', function () {
+      const client = new this.issuer.Client({
+        client_id: 'hs256-client',
+        client_secret: 'its gotta be a long secret and i mean at least 32 characters',
+        userinfo_signed_response_alg: 'HS256',
+      });
+
+      return client.joseSecret().then((key) => {
+        return new this.IdToken(key, 'HS256', {
+          iss: this.issuer.issuer,
+          sub: 'userId',
+          aud: client.client_id,
+          exp: now() + 3600,
+          iat: now(),
+        })
+          .then((token) => {
+            return client.validateIdToken(token, null, 'userinfo').then((validated) => {
+              expect(validated).to.equal(token);
+            });
+          });
+      });
+    });
+
+    it('validates the id_token_signed_response_alg is the one used', function () {
+      return this.client.joseSecret().then((key) => {
+        return new this.IdToken(key, 'HS256', {
+          iss: this.issuer.issuer,
+          sub: 'userId',
+          aud: this.client.client_id,
+          exp: now() + 3600,
+          iat: now(),
+        })
+          .then(token => this.client.validateIdToken(token))
+          .then(fail, (error) => {
+            expect(error).to.have.property('message', 'unexpected algorithm received');
+          });
+      });
+    });
+
+    it('verifies the azp', function () {
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        azp: 'not the client',
+        exp: now() + 3600,
+        iat: now(),
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token))
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 'azp must be the client_id');
         });
     });
 
-    it('encrypts for issuer using pre-shared client_secret (A\\d{3}KW)', function () {
+    it('verifies azp is present when more audiences are provided', function () {
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: [this.client.client_id, 'someone else'],
+        exp: now() + 3600,
+        iat: now(),
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token))
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 'missing required JWT property azp');
+        });
+    });
+
+    it('verifies the audience when azp is there', function () {
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: [this.client.client_id, 'someone else'],
+        azp: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token));
+    });
+
+    it('passes with nonce check', function () {
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        nonce: 'nonce!!!',
+        aud: [this.client.client_id, 'someone else'],
+        azp: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token, 'nonce!!!'));
+    });
+
+    it('validates nonce when provided to check for', function () {
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: [this.client.client_id, 'someone else'],
+        azp: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token, 'nonce!!!'))
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 'nonce mismatch');
+        });
+    });
+
+    it('validates nonce when in token', function () {
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        nonce: 'nonce!!!',
+        aud: [this.client.client_id, 'someone else'],
+        azp: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token))
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 'nonce mismatch');
+        });
+    });
+
+    ['iss', 'sub', 'aud', 'exp', 'iat'].forEach(function (prop) {
+      it(`verifies presence of payload property ${prop}`, function () {
+        const payload = {
+          iss: this.issuer.issuer,
+          sub: 'userId',
+          aud: this.client.client_id,
+          exp: now() + 3600,
+          iat: now(),
+        };
+
+        delete payload[prop];
+
+        return new this.IdToken(this.keystore.get(), 'RS256', payload)
+          .then(token => this.client.validateIdToken(token))
+          .then(fail, (error) => {
+            expect(error).to.have.property('message', `missing required JWT property ${prop}`);
+          });
+      });
+    });
+
+    it('verifies iat is a number', function () {
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: 'not a number',
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token))
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 'iat is not a number');
+        });
+    });
+
+    it('verifies iat is in the past', function () {
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now() + 20,
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token))
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 'id_token issued in the future');
+        });
+    });
+
+    it('allows iat skew', function () {
+      this.client.CLOCK_TOLERANCE = 5;
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now() + 5,
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token));
+    });
+
+    it('verifies exp is a number', function () {
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: 'not a nunmber',
+        iat: now(),
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token))
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 'exp is not a number');
+        });
+    });
+
+    it('verifies exp is in the future', function () {
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() - 100,
+        iat: now(),
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token))
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 'id_token expired');
+        });
+    });
+
+    it('allows exp skew', function () {
+      this.client.CLOCK_TOLERANCE = 5;
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() - 4,
+        iat: now(),
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token));
+    });
+
+    it('verifies nbf is a number', function () {
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+        nbf: 'notanumber',
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token))
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 'nbf is not a number');
+        });
+    });
+
+    it('verifies nbf is in the past', function () {
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+        nbf: now() + 20,
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token))
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 'id_token not active yet');
+        });
+    });
+
+    it('allows nbf skew', function () {
+      this.client.CLOCK_TOLERANCE = 5;
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+        nbf: now() + 5,
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token));
+    });
+
+    it('passes when auth_time is within max_age', function () {
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+        auth_time: now() - 200,
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token, null, null, 300));
+    });
+
+    it('verifies auth_time did not exceed max_age', function () {
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+        auth_time: now() - 600,
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token, null, null, 300))
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 'too much time has elapsed since the last End-User authentication');
+        });
+    });
+
+    it('allows auth_time skew', function () {
+      this.client.CLOCK_TOLERANCE = 5;
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+        auth_time: now() - 303,
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token, null, null, 300));
+    });
+
+    it('verifies auth_time is a number', function () {
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+        auth_time: 'foobar',
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token, null, null, 300))
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 'auth_time is not a number');
+        });
+    });
+
+    it('ignores auth_time presence check when require_auth_time is true but null is passed', function () {
       const client = new this.issuer.Client({
-        client_id: 'client_id',
-        client_secret: 'GfsT479VMy5ZZZPquadPbN3wKzaFGYo1CTkb0IFFzDNODLEAuC2GUV3QsTye3xNQ',
-        request_object_encryption_alg: 'A128KW',
+        client_id: 'with-require_auth_time',
+        require_auth_time: true,
       });
 
-      return client.requestObject({ state: 'foobar' })
-        .then((encrypted) => {
-          const parts = encrypted.split('.');
-          expect(JSON.parse(base64url.decode(parts[0]))).to.contain({ alg: 'A128KW', enc: 'A128CBC-HS256', cty: 'JWT' }).and.not.have.property('kid');
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => client.validateIdToken(token, null, null, null));
+    });
+
+    it('verifies auth_time is present when require_auth_time is true', function () {
+      const client = new this.issuer.Client({
+        client_id: 'with-require_auth_time',
+        require_auth_time: true,
+      });
+
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => client.validateIdToken(token))
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 'missing required JWT property auth_time');
         });
+    });
+
+    it('verifies auth_time is present when maxAge is passed', function () {
+      const payload = {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      };
+
+      return new this.IdToken(this.keystore.get(), 'RS256', payload)
+        .then(token => this.client.validateIdToken(token, null, null, 300))
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 'missing required JWT property auth_time');
+        });
+    });
+
+    it('passes with the right at_hash', function () {
+      const access_token = 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y'; // eslint-disable-line camelcase, max-len
+      const at_hash = '77QmUPtjPfzWtF2AnpK9RQ'; // eslint-disable-line camelcase
+
+      return new this.IdToken(this.keystore.get(), 'RS256', {
+        at_hash,
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      })
+        .then((token) => {
+          const tokenset = new TokenSet({ access_token, id_token: token });
+          return this.client.validateIdToken(tokenset);
+        });
+    });
+
+    it('validates at_hash presence for implicit flow', function () {
+      const access_token = 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y'; // eslint-disable-line camelcase, max-len
+
+      return new this.IdToken(this.keystore.get(), 'RS256', {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      })
+        .then((token) => {
+        // const tokenset = new TokenSet();
+          return this.client.authorizationCallback(null, { access_token, id_token: token });
+        })
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 'missing required property at_hash');
+        });
+    });
+
+    it('validates c_hash presence for hybrid flow', function () {
+      const code = 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y'; // eslint-disable-line camelcase, max-len
+
+      return new this.IdToken(this.keystore.get(), 'RS256', {
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      })
+        .then((token) => {
+        // const tokenset = new TokenSet();
+          return this.client.authorizationCallback(null, { code, id_token: token });
+        })
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 'missing required property c_hash');
+        });
+    });
+
+    it('validates state presence when s_hash is returned', function () {
+      const s_hash = '77QmUPtjPfzWtF2AnpK9RQ'; // eslint-disable-line camelcase
+
+      return new this.IdToken(this.keystore.get(), 'RS256', {
+        s_hash,
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      })
+        .then((token) => {
+          return this.client.authorizationCallback(null, { id_token: token });
+        })
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 'cannot verify s_hash, state not provided');
+        });
+    });
+
+    it('validates s_hash', function () {
+      const state = 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y'; // eslint-disable-line camelcase, max-len
+      const s_hash = 'foobar'; // eslint-disable-line camelcase
+
+      return new this.IdToken(this.keystore.get(), 'RS256', {
+        s_hash,
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      })
+        .then((token) => {
+          return this.client.authorizationCallback(null, { id_token: token, state }, { state });
+        })
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 's_hash mismatch');
+        });
+    });
+
+    it('passes with the right s_hash', function () {
+      const state = 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y'; // eslint-disable-line camelcase, max-len
+      const s_hash = '77QmUPtjPfzWtF2AnpK9RQ'; // eslint-disable-line camelcase
+
+      return new this.IdToken(this.keystore.get(), 'RS256', {
+        s_hash,
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      })
+        .then((token) => {
+          return this.client.authorizationCallback(null, { id_token: token, state }, { state });
+        });
+    });
+
+    it('fails with the wrong at_hash', function () {
+      const access_token = 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y'; // eslint-disable-line camelcase, max-len
+      const at_hash = 'notvalid77QmUPtjPfzWtF2AnpK9RQ'; // eslint-disable-line camelcase
+
+      return new this.IdToken(this.keystore.get(), 'RS256', {
+        at_hash,
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      })
+        .then((token) => {
+          const tokenset = new TokenSet({ access_token, id_token: token });
+          return this.client.validateIdToken(tokenset);
+        })
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 'at_hash mismatch');
+        });
+    });
+
+    it('passes with the right c_hash', function () {
+      const code = 'Qcb0Orv1zh30vL1MPRsbm-diHiMwcLyZvn1arpZv-Jxf_11jnpEX3Tgfvk'; // eslint-disable-line camelcase, max-len
+      const c_hash = 'LDktKdoQak3Pk0cnXxCltA'; // eslint-disable-line camelcase
+
+      return new this.IdToken(this.keystore.get(), 'RS256', {
+        c_hash,
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      })
+        .then((token) => {
+          const tokenset = new TokenSet({ code, id_token: token });
+          return this.client.validateIdToken(tokenset);
+        });
+    });
+
+    it('fails with the wrong c_hash', function () {
+      const code = 'Qcb0Orv1zh30vL1MPRsbm-diHiMwcLyZvn1arpZv-Jxf_11jnpEX3Tgfvk'; // eslint-disable-line camelcase, max-len
+      const c_hash = 'notvalidLDktKdoQak3Pk0cnXxCltA'; // eslint-disable-line camelcase
+
+      return new this.IdToken(this.keystore.get(), 'RS256', {
+        c_hash,
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      })
+        .then((token) => {
+          const tokenset = new TokenSet({ code, id_token: token });
+          return this.client.validateIdToken(tokenset);
+        })
+        .then(fail, (error) => {
+          expect(error).to.have.property('message', 'c_hash mismatch');
+        });
+    });
+
+    it('fails if tokenset without id_token is passed in', function () {
+      expect(() => {
+        this.client.validateIdToken(new TokenSet({
+          access_token: 'tokenValue',
+          // id_token not
+        }));
+      }).to.throw('id_token not present in TokenSet');
+    });
+  });
+
+  describe('Distributed and Aggregated Claims', function () {
+    function getJWT(payload, issuer) {
+      const iss = issuer.startsWith('http') ? issuer : `https://${issuer}-iss.example.com`;
+      let keystore;
+      payload.iss = iss;
+
+      if (Registry.has(iss)) {
+        keystore = Registry.get(iss).keystore();
+      } else {
+        const store = jose.JWK.createKeyStore();
+        keystore = store.generate('RSA', 512).then(function () {
+          const i = new Issuer({ issuer: iss, jwks_uri: `${iss}/certs` });
+
+          nock(iss)
+            .persist()
+            .get('/certs')
+            .reply(200, store.toJSON(true));
+
+          return i.keystore();
+        });
+      }
+
+      return keystore.then(function (k) {
+        return jose.JWS.createSign({
+          fields: {
+            alg: 'RS256',
+            typ: 'JWT',
+          },
+          format: 'compact',
+        }, { key: k.get() }).update(JSON.stringify(payload)).final();
+      });
+    }
+
+    describe('Client#fetchDistributedClaims', function () {
+      afterEach(nock.cleanAll);
+      before(function () {
+        const issuer = new Issuer({
+          issuer: 'https://op.example.com',
+          jwks_uri: 'https://op.example.com/jwks',
+          authorization_endpoint: 'https://op.example.com/auth',
+        });
+        this.client = new issuer.Client({
+          client_id: 'identifier',
+        });
+        const store = jose.JWK.createKeyStore();
+
+        return store.generate('RSA', 512).then(() => {
+          nock(issuer.issuer)
+            .get('/jwks')
+            .reply(200, store.toJSON(true));
+
+          return issuer.keystore();
+        });
+      });
+
+      it('just returns userinfo if no distributed claims are to be fetched', function () {
+        const userinfo = {
+          sub: 'userID',
+          _claim_sources: {
+            src1: { JWT: 'not distributed' },
+          },
+        };
+        return this.client.fetchDistributedClaims(userinfo)
+          .then((result) => {
+            expect(result).to.equal(userinfo);
+          });
+      });
+
+      it('fetches the claims from one or more distributed sources', function () {
+        return Promise.all([
+          getJWT({ credit_history: 'foobar' }, 'src1'),
+          getJWT({ email: 'foobar@example.com' }, 'src2'),
+          getJWT({ gender: 'male' }, this.client.issuer.issuer),
+        ]).then((jwts) => {
+          nock('https://src1.example.com')
+            .get('/claims').reply(200, jwts[0]);
+          nock('https://src2.example.com')
+            .get('/claims').reply(200, jwts[1]);
+          nock('https://src3.example.com')
+            .get('/claims').reply(200, [{ alg: 'none' }, { age: 27 }, ''].map((comp) => {
+              if (typeof comp === 'object') {
+                return base64url(JSON.stringify(comp));
+              }
+              return comp;
+            }).join('.'));
+          nock(this.client.issuer.issuer)
+            .get('/claims').reply(200, jwts[2]);
+
+          const userinfo = {
+            sub: 'userID',
+            _claim_names: {
+              credit_history: 'src1',
+              email: 'src2',
+              age: 'src3',
+              gender: 'src4',
+            },
+            _claim_sources: {
+              src1: { endpoint: 'https://src1.example.com/claims', access_token: 'foobar' },
+              src2: { endpoint: 'https://src2.example.com/claims' },
+              src3: { endpoint: 'https://src3.example.com/claims' },
+              src4: { endpoint: `${this.client.issuer.issuer}/claims` },
+            },
+          };
+
+          return this.client.fetchDistributedClaims(userinfo)
+            .then((result) => {
+              expect(result).to.eql({
+                gender: 'male',
+                age: 27,
+                sub: 'userID',
+                credit_history: 'foobar',
+                email: 'foobar@example.com',
+              });
+              expect(result).to.equal(userinfo);
+            });
+        });
+      });
+
+      it('uses access token from provided param if not part of the claims', function () {
+        return getJWT({ credit_history: 'foobar' }, 'src1').then((jwt) => {
+          nock('https://src1.example.com')
+            .matchHeader('authorization', 'Bearer foobar')
+            .get('/claims').reply(200, jwt);
+
+          const userinfo = {
+            sub: 'userID',
+            _claim_names: {
+              credit_history: 'src1',
+            },
+            _claim_sources: {
+              src1: { endpoint: 'https://src1.example.com/claims' },
+            },
+          };
+
+          return this.client.fetchDistributedClaims(userinfo, { src1: 'foobar' })
+            .then((result) => {
+              expect(result).to.eql({
+                sub: 'userID',
+                credit_history: 'foobar',
+              });
+              expect(result).to.equal(userinfo);
+            });
+        });
+      });
+
+      it('validates claims that should be present are', function () {
+        return getJWT({
+          // credit_history: 'foobar',
+        }, 'src1').then((jwt) => {
+          nock('https://src1.example.com')
+            .get('/claims').reply(200, jwt);
+
+          const userinfo = {
+            sub: 'userID',
+            _claim_names: {
+              credit_history: 'src1',
+            },
+            _claim_sources: {
+              src1: { endpoint: 'https://src1.example.com/claims' },
+            },
+          };
+
+          return this.client.fetchDistributedClaims(userinfo)
+            .then(fail, function (error) {
+              expect(error).to.have.property('src', 'src1');
+              expect(error.message).to.equal('expected claim "credit_history" in "src1"');
+            });
+        });
+      });
+
+      it('is rejected with OpenIdConnectError upon oidc error', function () {
+        nock('https://src1.example.com')
+          .get('/claims')
+          .reply(401, {
+            error: 'invalid_token',
+            error_description: 'bad things are happening',
+          });
+
+        const userinfo = {
+          sub: 'userID',
+          _claim_names: {
+            credit_history: 'src1',
+          },
+          _claim_sources: {
+            src1: { endpoint: 'https://src1.example.com/claims', access_token: 'foobar' },
+          },
+        };
+
+        return this.client.fetchDistributedClaims(userinfo)
+          .then(fail, function (error) {
+            expect(error.name).to.equal('OpenIdConnectError');
+            expect(error).to.have.property('message', 'invalid_token');
+            expect(error).to.have.property('src', 'src1');
+          });
+      });
+    });
+
+    describe('Client#unpackAggregatedClaims', function () {
+      before(function () {
+        const issuer = new Issuer({
+          authorization_endpoint: 'https://op.example.com/auth',
+        });
+        this.client = new issuer.Client({
+          client_id: 'identifier',
+        });
+      });
+
+      it('just returns userinfo if no aggregated claims are to be unpacked', function () {
+        const userinfo = {
+          sub: 'userID',
+          _claim_sources: {
+            src1: { endpoint: 'not distributed' },
+          },
+        };
+        return this.client.unpackAggregatedClaims(userinfo)
+          .then((result) => {
+            expect(result).to.equal(userinfo);
+          });
+      });
+
+      it('unpacks the claims from one or more aggregated sources', function () {
+        return Promise.all([
+          getJWT({ credit_history: 'foobar' }, 'src1'),
+          getJWT({ email: 'foobar@example.com' }, 'src2'),
+        ]).then((jwts) => {
+          const userinfo = {
+            sub: 'userID',
+            _claim_names: {
+              credit_history: 'src1',
+              email: 'src2',
+            },
+            _claim_sources: {
+              src1: { JWT: jwts[0] },
+              src2: { JWT: jwts[1] },
+            },
+          };
+
+          return this.client.unpackAggregatedClaims(userinfo)
+            .then((result) => {
+              expect(result).to.eql({
+                sub: 'userID',
+                credit_history: 'foobar',
+                email: 'foobar@example.com',
+              });
+              expect(result).to.equal(userinfo);
+            });
+        });
+      });
+
+      it('autodiscovers new issuers', function () {
+        return getJWT({ email_verified: false }, 'cliff').then((cliff) => {
+          const userinfo = {
+            sub: 'userID',
+            _claim_names: {
+              email_verified: 'cliff',
+            },
+            _claim_sources: {
+              cliff: { JWT: cliff },
+            },
+          };
+
+          const iss = 'https://cliff-iss.example.com';
+
+          const discovery = nock(iss)
+            .get('/.well-known/openid-configuration')
+            .reply(200, {
+              issuer: iss,
+              jwks_uri: `${iss}/certs`,
+            });
+
+          Registry.delete(iss);
+
+          return this.client.unpackAggregatedClaims(userinfo)
+            .then((result) => {
+              expect(result).to.eql({
+                sub: 'userID',
+                email_verified: false,
+              });
+              expect(result).to.equal(userinfo);
+              expect(discovery.isDone()).to.be.true;
+            });
+        });
+      });
+
+      it('validates claims that should be present are', function () {
+        return getJWT({}, 'src1').then((jwt) => {
+          const userinfo = {
+            sub: 'userID',
+            _claim_names: {
+              credit_history: 'src1',
+            },
+            _claim_sources: {
+              src1: { JWT: jwt },
+            },
+          };
+
+          return this.client.unpackAggregatedClaims(userinfo)
+            .then(fail, function (error) {
+              expect(error).to.have.property('src', 'src1');
+              expect(error.message).to.equal('expected claim "credit_history" in "src1"');
+            });
+        });
+      });
+
+      it('rejects discovery errors', function () {
+        return getJWT({ email_verified: false }, 'cliff').then((cliff) => {
+          const userinfo = {
+            sub: 'userID',
+            _claim_names: {
+              email_verified: 'cliff',
+            },
+            _claim_sources: {
+              cliff: { JWT: cliff },
+            },
+          };
+
+          const iss = 'https://cliff-iss.example.com';
+
+          const discovery = nock(iss)
+            .get('/.well-known/openid-configuration')
+            .reply(500, 'Internal Server Error');
+
+          Registry.delete(iss);
+
+          return this.client.unpackAggregatedClaims(userinfo)
+            .then(fail, (error) => {
+              expect(discovery.isDone()).to.be.true;
+              expect(error.name).to.equal('HTTPError');
+              expect(error.src).to.equal('cliff');
+            });
+        });
+      });
+
+      it('rejects JWT errors', function () {
+        const userinfo = {
+          sub: 'userID',
+          _claim_names: {
+            email_verified: 'src1',
+          },
+          _claim_sources: {
+            src1: { JWT: 'not.a.jwt' },
+          },
+        };
+
+        return this.client.unpackAggregatedClaims(userinfo)
+          .then(fail, (error) => {
+            expect(error.src).to.equal('src1');
+          });
+      });
+    });
+
+
+    /* eslint-disable max-len */
+    describe('signed and encrypted responses', function () {
+      before(function () {
+        return jose.JWK.asKeyStore({
+          keys: [
+            {
+              kty: 'EC',
+              kid: 'L3qrG8dSNYv6F-Hvv-qTdp_EkmgwjQX76DHmDZCoa4Q',
+              crv: 'P-256',
+              x: 'PDsKZY9JxlbrE-hHce_e_H7yjWgxftRIowdW9qxBqNQ',
+              y: 'EAmrpjkbBkuBZAD2kvuL5mOXgdK_8t1t93yKGGHq_Y4',
+              d: '59efvkfuCuVLW9Y4xvLvUyjARwgnSgwTLRc0UGpewLA',
+            },
+          ],
+        }).then((keystore) => { this.keystore = keystore; });
+      });
+
+      it('handles signed and encrypted id_tokens from implicit and code responses (test by hybrid)', function () {
+        const time = new Date(1473076413242);
+        timekeeper.freeze(time);
+        const issuer = new Issuer({
+          issuer: 'https://guarded-cliffs-8635.herokuapp.com/op',
+          token_endpoint: 'https://op.example.com/token',
+          userinfo_endpoint: 'https://op.example.com/me',
+        });
+
+        nock('https://op.example.com')
+          .post('/token')
+          .reply(200, {
+            access_token: 'eyJraW5kIjoiQWNjZXNzVG9rZW4iLCJqdGkiOiJlMDk5YTI1ZC02MzA0LTQwMGItOTdhYi1hOTJhMzMzOTBlODgiLCJpYXQiOjE0NzMwNzY0MTMsImV4cCI6MTQ3MzA4MzYxMywiaXNzIjoiaHR0cHM6Ly9ndWFyZGVkLWNsaWZmcy04NjM1Lmhlcm9rdWFwcC5jb20vb3AifQ.p_r4KvAu6lEY6JpGmRIGCkRRrovGeJcDfOw3O_gFkPRaY7bcJjNDUPlfY7_nyp3bWyqtveq55ozTZuddUL01KET7bKgxMq-dQ2SxGBvgN3KtHIRBud7Bw8Ax98YkiBKJJXC8xF00VZkkX-ZcUyXptPkUpBm0zeN6jmWmyFX-2QrbclLS8ZEK2Poc_y5PdNAtCCOTBfnq6roxzVQ5lM_aMQaSuPVd-Og6E_jBE6OE9oB4ikFa4S7EvZvFVDpGMLtUjxOazTURbqWY6OnuhuAiP6WZc1FxfQod462IqPERzl2qVJH9qQNr-iLuVLt_bzauHg33v1koTrdfETyoRAZH5w',
+            expires_at: 1473083613,
+            id_token: 'eyJhbGciOiJFQ0RILUVTK0ExMjhLVyIsImtpZCI6IkwzcXJHOGRTTll2NkYtSHZ2LXFUZHBfRWttZ3dqUVg3NkRIbURaQ29hNFEiLCJlcGsiOnsia3R5IjoiRUMiLCJjcnYiOiJQLTI1NiIsIngiOiJJVXRTWnZOVzBubUNmT2Nwek5JSnBBS29FbGpOVkZyUlJGa2pDT3plYnlRIiwieSI6IjNEOXZ1V2VJNEdVajZWczZ4ZUJlMVZRM3dHQnhkU3BnTGdYcGZPUThmeEkifSwiZW5jIjoiQTEyOENCQy1IUzI1NiIsImN0eSI6IkpXVCJ9.DVIPxvxnQASDiair_I_6e4M1Y8yMdzIneHMPq_LlBjo8QAiwjMQ1Uw.gdLKThNa_DcFmPGBmzOBkg.TQZ4qpEchLx9nnNIfG_N8d3sL-S-p1vpWbA3MnK68U60kX7i29s33fxhH3w5MQhZbgxjntrbRdE9wFsBzclr8hfwazBTpi6D5Ignug0xCZQYw7HBDrkq63-7PQQa2-rivTtxQxAWUZj7dnNE4Ixo9qaBkHod1EPf5xameCDzgrRa2oi2ISEE6ncQrvc7jnANeBQj0Q2OLmo9L7EIVQbEKejGfZ_0p5HiXmgFMpLbkLFwYhTdpiSUCkZlcym-e2tgbzHJmtF85cx2-yDwDNGLvY8y5ytW79_k_ckbHKVTjf_jRMagqM7Mt6TQ1fhm9T7FZ4q-96L0ItGb12jar2Aw6VWP1DAwUMZ1jA8mmllsWu-y7qc9Ert5rlJ7osZzMOgaNfX1sf5Xa7aOHysC-tVxknIPtxAamVJ7REGxmii-FO6En4zgJMt1PLUoTTK4tIpIX06VWDKI-dQzn46ple9xeuzCUvpvap823Xl9ONcVj4AF-YmHU-UkT96gx_6Owqcwm6synOh1l2O9rRi9jJnCg6egTqn1MHaVhTYaVhKQQUpE-voAoXoaJDoLQX2fC6IjF5H2xnc_1k61wGBJkX_7zqagNYGJyoluiQr5EGkB8pxANJVHNIW37ezJEIjnix5h_Fwzh_XElGzVsKeB-ih9X6ECSVJ1VIPopN5t38kGa8lQuM7vLr0i__cvYP8TgyE94nllEl-5f0gHOUQrpcUEqpsZYRBGcW_m8iU3nuvD0Em6nCvvzPUvlmCRyANQbs3A.H9oTPRc3ahVDUuYj3C9-gQ',
+            refresh_token: 'eyJraW5kIjoiUmVmcmVzaFRva2VuIiwianRpIjoiMzhmZTY1NmItNjYyMC00MzdiLWJmY2YtZTRjNzRhZTRiNjMzIiwibm9uY2UiOiJjNjQ1ZmZmYTQwMDc1NTMyZWYyOWEyZWE2MjdjZmEzNyIsImlhdCI6MTQ3MzA3NjQxMywiZXhwIjoxNDc1NjY4NDEzLCJpc3MiOiJodHRwczovL2d1YXJkZWQtY2xpZmZzLTg2MzUuaGVyb2t1YXBwLmNvbS9vcCJ9.hySAknc2L2ngSoTiRxUTJLOUxKmyRTUzLsRlGKip4OXNYXre9QEDH8z9c8NKBHdnRbBxg8Jo45cZbDb-5bZ6mt5noDmT42xtsCOiN25Is9SsRSzVarIDiwyqXVlTojh5XuKPulK4Ji6vp2jYUZNoVnlsA7G96cuHWVAqZd5e8GBb9YlUNZ5zSX6aggFgTGDJs46O42_g4JULB8cAb9MZAzcZOORGpmRIPpSKAZFgT2_5yW-yqh0f66JaAQUtW9TKoAsdttV4NnivzJYeyR0hlgEeKzo9zNuTkJedXbjRAIP6ybk9ITcZveuJ11CFsyHZcNd_0tZuiAlvUpJIeHK0aA',
+            token_type: 'Bearer',
+          });
+
+        const client = new issuer.Client({
+          client_id: '4e87dde4-ddd3-4c21-aef9-2f2f6bab43ca',
+          client_secret: 'GfsT479VMy5ZZZPquadPbN3wKzaFGYo1CTkb0IFFzDNODLEAuC2GUV3QsTye3xNQ',
+          id_token_encrypted_response_alg: 'ECDH-ES+A128KW',
+          id_token_encrypted_response_enc: 'A128CBC-HS256',
+          id_token_signed_response_alg: 'HS256',
+        }, this.keystore);
+
+        return client.authorizationCallback('http://oidc-client.dev/cb', {
+          code: 'eyJraW5kIjoiQXV0aG9yaXphdGlvbkNvZGUiLCJqdGkiOiI3YzM5NzQyZC0yMGUyLTQ3YjEtYmM1MC1lN2VlYzhmN2IzNmYiLCJub25jZSI6ImM2NDVmZmZhNDAwNzU1MzJlZjI5YTJlYTYyN2NmYTM3IiwiaWF0IjoxNDczMDc2NDEyLCJleHAiOjE0NzMwNzcwMTIsImlzcyI6Imh0dHBzOi8vZ3VhcmRlZC1jbGlmZnMtODYzNS5oZXJva3VhcHAuY29tL29wIn0.jgUnZUBmsceb1cpqlsmiCOQ40Zx4JTRffGN_bAgYT4rLcEv3wOlzMSoVmU1cYkDbi-jjNAqkBjqxDWHcRJnQR4BAYOdyDVcGWD_aLkqGhUOCJHn_lwWqEKtSTgh-zXiqVIVC5NTA2BdhEfHhb-jnMQNrKkL2QNXOFvT9s6khZozOMXy-mUdfNfdSFHrcpFkFyGAUpezI9QmwToMB6KwoRHDYb2jcLBXdA5JLAnHw8lpz9yUaVQv7s97wY7Xgtt2zNFwQxiJWytYNHaJxQnOZje0_TvDjrZSA9IYKuKU1Q7f7-EBfQfFSGcsFK2NtGho3mNBEUDD2B8Qv1ipv50oU6Q',
+          id_token: 'eyJhbGciOiJFQ0RILUVTK0ExMjhLVyIsImtpZCI6IkwzcXJHOGRTTll2NkYtSHZ2LXFUZHBfRWttZ3dqUVg3NkRIbURaQ29hNFEiLCJlcGsiOnsia3R5IjoiRUMiLCJjcnYiOiJQLTI1NiIsIngiOiJyellvRzJXeTZtSWhIZ01pMk1SNmd0alpPbG40SzZnSVExVU0yS0tOaFBjIiwieSI6IjF0TmNVZTJSNHBPM2NRZUVtQTF6Z1AzNVdXV19xSUNCMDY3WHFZZGJPSXMifSwiZW5jIjoiQTEyOENCQy1IUzI1NiIsImN0eSI6IkpXVCJ9.yMWht5iTHhr6EKd-Dy7vw_qkRnuh7RtFpLWfs0TOQ6IAIF6K5ieUKw.-wtcftFYgbs7Rj1g-zKaXw.s8BposTeAeUdqSIjKKYADk5THIP33_nLNmGcScQ94vHApM6lUeuMPNdtjGIRJfLoBnIjr0JLYUX_oB-8nXxDCgV19alT0xzc9bKMbb6FR7gHS4R6nVUFAumtpl50iwFs-xGIcVsrr76lQJv5m139EqSeCXse2OY8Q0YyBJgEb_hL4kDXpqxwAd-VqyQzyrAXd_pIlVUnydZ6BC4ZPvbN7RJPR8z1EN46GEYknweuyhT_5tD4FkcngJPRoXJ_KnEr9Q7qbIbCWMmn6bBO59uvv-MXCM2PXIaRNTwZ2_Vp0pB6LkmVC6kHcsotBBGzc-TH_5t87t4JhB1XtTyfl_Nn1YCETdVh8iJUTk_F6ntokka0PTvjXfVQZkqZHT6j6PqZzqMngHNh2lxaFRod9DxT00QEDHXoBGaMDIjBMAt0vI4vIeXqxIMtqJ3i8FMm9bociXo5kpRDgBgmTllJ8O7GDw5q0M7ZIg5dRr0aph8TeXDImwvbPhk32T6tXJVg1i8N7dTICVc0BTitp4cIw2TFXoiR3eSyLusrJ4H3qe-SNJUoq0sPBwzg1tEiDbsDaHhxiwLRu1rcyOcXEqT5Ry0bJM09I_ypEAX9JoA_5NbiY1PVx7rMDxDUreEBW_1xEG8rgXkAmVHHZWLUiEmxQ4RCnityGKIEbG7OFjOOd6CXuznnBEDV-F120bcDCaIClwYI.yFz2AdC2eJ7GX-9gYUMy8Q',
+          state: '36853f4ea7c9d26f4b0b95f126afe6a2',
+          session_state: 'foobar.foo',
+        }, { state: '36853f4ea7c9d26f4b0b95f126afe6a2', nonce: 'c645fffa40075532ef29a2ea627cfa37' });
+      });
+
+      it('handles signed and encrypted id_tokens from refresh grant', function () {
+        const time = new Date(1473076413242);
+        timekeeper.freeze(time);
+        const issuer = new Issuer({
+          issuer: 'https://guarded-cliffs-8635.herokuapp.com/op',
+          token_endpoint: 'https://op.example.com/token',
+        });
+
+        nock('https://op.example.com')
+          .post('/token')
+          .reply(200, {
+            access_token: 'eyJraW5kIjoiQWNjZXNzVG9rZW4iLCJqdGkiOiJlMDk5YTI1ZC02MzA0LTQwMGItOTdhYi1hOTJhMzMzOTBlODgiLCJpYXQiOjE0NzMwNzY0MTMsImV4cCI6MTQ3MzA4MzYxMywiaXNzIjoiaHR0cHM6Ly9ndWFyZGVkLWNsaWZmcy04NjM1Lmhlcm9rdWFwcC5jb20vb3AifQ.p_r4KvAu6lEY6JpGmRIGCkRRrovGeJcDfOw3O_gFkPRaY7bcJjNDUPlfY7_nyp3bWyqtveq55ozTZuddUL01KET7bKgxMq-dQ2SxGBvgN3KtHIRBud7Bw8Ax98YkiBKJJXC8xF00VZkkX-ZcUyXptPkUpBm0zeN6jmWmyFX-2QrbclLS8ZEK2Poc_y5PdNAtCCOTBfnq6roxzVQ5lM_aMQaSuPVd-Og6E_jBE6OE9oB4ikFa4S7EvZvFVDpGMLtUjxOazTURbqWY6OnuhuAiP6WZc1FxfQod462IqPERzl2qVJH9qQNr-iLuVLt_bzauHg33v1koTrdfETyoRAZH5w',
+            expires_at: 1473083613,
+            id_token: 'eyJhbGciOiJFQ0RILUVTK0ExMjhLVyIsImtpZCI6IkwzcXJHOGRTTll2NkYtSHZ2LXFUZHBfRWttZ3dqUVg3NkRIbURaQ29hNFEiLCJlcGsiOnsia3R5IjoiRUMiLCJjcnYiOiJQLTI1NiIsIngiOiJJVXRTWnZOVzBubUNmT2Nwek5JSnBBS29FbGpOVkZyUlJGa2pDT3plYnlRIiwieSI6IjNEOXZ1V2VJNEdVajZWczZ4ZUJlMVZRM3dHQnhkU3BnTGdYcGZPUThmeEkifSwiZW5jIjoiQTEyOENCQy1IUzI1NiIsImN0eSI6IkpXVCJ9.DVIPxvxnQASDiair_I_6e4M1Y8yMdzIneHMPq_LlBjo8QAiwjMQ1Uw.gdLKThNa_DcFmPGBmzOBkg.TQZ4qpEchLx9nnNIfG_N8d3sL-S-p1vpWbA3MnK68U60kX7i29s33fxhH3w5MQhZbgxjntrbRdE9wFsBzclr8hfwazBTpi6D5Ignug0xCZQYw7HBDrkq63-7PQQa2-rivTtxQxAWUZj7dnNE4Ixo9qaBkHod1EPf5xameCDzgrRa2oi2ISEE6ncQrvc7jnANeBQj0Q2OLmo9L7EIVQbEKejGfZ_0p5HiXmgFMpLbkLFwYhTdpiSUCkZlcym-e2tgbzHJmtF85cx2-yDwDNGLvY8y5ytW79_k_ckbHKVTjf_jRMagqM7Mt6TQ1fhm9T7FZ4q-96L0ItGb12jar2Aw6VWP1DAwUMZ1jA8mmllsWu-y7qc9Ert5rlJ7osZzMOgaNfX1sf5Xa7aOHysC-tVxknIPtxAamVJ7REGxmii-FO6En4zgJMt1PLUoTTK4tIpIX06VWDKI-dQzn46ple9xeuzCUvpvap823Xl9ONcVj4AF-YmHU-UkT96gx_6Owqcwm6synOh1l2O9rRi9jJnCg6egTqn1MHaVhTYaVhKQQUpE-voAoXoaJDoLQX2fC6IjF5H2xnc_1k61wGBJkX_7zqagNYGJyoluiQr5EGkB8pxANJVHNIW37ezJEIjnix5h_Fwzh_XElGzVsKeB-ih9X6ECSVJ1VIPopN5t38kGa8lQuM7vLr0i__cvYP8TgyE94nllEl-5f0gHOUQrpcUEqpsZYRBGcW_m8iU3nuvD0Em6nCvvzPUvlmCRyANQbs3A.H9oTPRc3ahVDUuYj3C9-gQ',
+            refresh_token: 'eyJraW5kIjoiUmVmcmVzaFRva2VuIiwianRpIjoiMzhmZTY1NmItNjYyMC00MzdiLWJmY2YtZTRjNzRhZTRiNjMzIiwibm9uY2UiOiJjNjQ1ZmZmYTQwMDc1NTMyZWYyOWEyZWE2MjdjZmEzNyIsImlhdCI6MTQ3MzA3NjQxMywiZXhwIjoxNDc1NjY4NDEzLCJpc3MiOiJodHRwczovL2d1YXJkZWQtY2xpZmZzLTg2MzUuaGVyb2t1YXBwLmNvbS9vcCJ9.hySAknc2L2ngSoTiRxUTJLOUxKmyRTUzLsRlGKip4OXNYXre9QEDH8z9c8NKBHdnRbBxg8Jo45cZbDb-5bZ6mt5noDmT42xtsCOiN25Is9SsRSzVarIDiwyqXVlTojh5XuKPulK4Ji6vp2jYUZNoVnlsA7G96cuHWVAqZd5e8GBb9YlUNZ5zSX6aggFgTGDJs46O42_g4JULB8cAb9MZAzcZOORGpmRIPpSKAZFgT2_5yW-yqh0f66JaAQUtW9TKoAsdttV4NnivzJYeyR0hlgEeKzo9zNuTkJedXbjRAIP6ybk9ITcZveuJ11CFsyHZcNd_0tZuiAlvUpJIeHK0aA',
+            token_type: 'Bearer',
+          });
+
+        const client = new issuer.Client({
+          client_id: '4e87dde4-ddd3-4c21-aef9-2f2f6bab43ca',
+          client_secret: 'GfsT479VMy5ZZZPquadPbN3wKzaFGYo1CTkb0IFFzDNODLEAuC2GUV3QsTye3xNQ',
+          id_token_encrypted_response_alg: 'ECDH-ES+A128KW',
+          id_token_encrypted_response_enc: 'A128CBC-HS256',
+          id_token_signed_response_alg: 'HS256',
+        }, this.keystore);
+
+        return client.refresh('http://oidc-client.dev/cb', new TokenSet({
+          refresh_token: 'eyJraW5kIjoiUmVmcmVzaFRva2VuIiwianRpIjoiMzhmZTY1NmItNjYyMC00MzdiLWJmY2YtZTRjNzRhZTRiNjMzIiwibm9uY2UiOiJjNjQ1ZmZmYTQwMDc1NTMyZWYyOWEyZWE2MjdjZmEzNyIsImlhdCI6MTQ3MzA3NjQxMywiZXhwIjoxNDc1NjY4NDEzLCJpc3MiOiJodHRwczovL2d1YXJkZWQtY2xpZmZzLTg2MzUuaGVyb2t1YXBwLmNvbS9vcCJ9.hySAknc2L2ngSoTiRxUTJLOUxKmyRTUzLsRlGKip4OXNYXre9QEDH8z9c8NKBHdnRbBxg8Jo45cZbDb-5bZ6mt5noDmT42xtsCOiN25Is9SsRSzVarIDiwyqXVlTojh5XuKPulK4Ji6vp2jYUZNoVnlsA7G96cuHWVAqZd5e8GBb9YlUNZ5zSX6aggFgTGDJs46O42_g4JULB8cAb9MZAzcZOORGpmRIPpSKAZFgT2_5yW-yqh0f66JaAQUtW9TKoAsdttV4NnivzJYeyR0hlgEeKzo9zNuTkJedXbjRAIP6ybk9ITcZveuJ11CFsyHZcNd_0tZuiAlvUpJIeHK0aA',
+        }), { nonce: null });
+      });
+
+      it('handles encrypted but not signed responses too', function () {
+        const time = new Date(1473076413242);
+        timekeeper.freeze(time);
+        const issuer = new Issuer({
+          issuer: 'https://guarded-cliffs-8635.herokuapp.com/op',
+          userinfo_endpoint: 'https://op.example.com/me',
+        });
+
+        nock('https://op.example.com')
+          .get('/me')
+          .reply(200, 'eyJhbGciOiJFQ0RILUVTK0ExMjhLVyIsImtpZCI6IkwzcXJHOGRTTll2NkYtSHZ2LXFUZHBfRWttZ3dqUVg3NkRIbURaQ29hNFEiLCJlcGsiOnsia3R5IjoiRUMiLCJjcnYiOiJQLTI1NiIsIngiOiI4SUpmUTJQU3JBTFlqd0oyd3ZXWGZoTDJGRmgyekRxVUU1dHpZRVYybTVJIiwieSI6IjhfRkFIdzVzZmJ2c1drQ0ZRLW1mN2I3VVFYempWS0UyNWE3LXVKbEZoZUkifSwiZW5jIjoiQTEyOENCQy1IUzI1NiIsImN0eSI6IkpXVCJ9.KnATIoEGwPKAJHyKAKGVjmeuu4PmsKjXydV047kqzUzXFHPes60zSg.D50tt0pN1HygTtOs5Hu26Q.RWmwnKdALaafgNy3X9Zvvnb27XvJiDqFKQ9kqIOFBV-MtG0Q5dQaB5v6ldaExWTyugGAtP_s1LS8zlX-E9V5eHeXmJkYn9qIQbjJ9eHdHLk.uypPS5AVSBN9XNGqeVrzuQ', {
+            'content-type': 'application/jwt; charset=utf-8',
+          });
+
+        const client = new issuer.Client({
+          client_id: 'f21d5d1d-1c3f-4905-8ff1-5f553a2090b1',
+          userinfo_encrypted_response_alg: 'ECDH-ES+A128KW',
+          userinfo_encrypted_response_enc: 'A128CBC-HS256',
+        }, this.keystore);
+
+        return client.userinfo('accesstoken').then((userinfo) => {
+          expect(userinfo).to.eql({
+            email: 'johndoe@example.com',
+            sub: '0aa66887-8c86-4f3b-b521-5a00e01799ca',
+          });
+        });
+      });
+
+      it('handles symmetric encryption', function () {
+        const time = new Date(1474477036849);
+        timekeeper.freeze(time);
+        const issuer = new Issuer({ issuer: 'http://localhost:3000/op' });
+
+        const client = new issuer.Client({
+          client_id: '0d9413a4-61c1-4b2b-8d84-a82464c1556c',
+          client_secret: 'l73jho9z9mL0GAomiQwbw08ARqro2tJ4E4qhJ+PZhNQoU6G6D23UDF91L9VR7iJ4',
+          id_token_encrypted_response_alg: 'A128KW',
+          id_token_encrypted_response_enc: 'A128CBC-HS256',
+          id_token_signed_response_alg: 'HS256',
+        });
+
+        return client.authorizationCallback('http://oidc-client.dev/cb', {
+          id_token: 'eyJhbGciOiJBMTI4S1ciLCJlbmMiOiJBMTI4Q0JDLUhTMjU2IiwiY3R5IjoiSldUIn0.mAnRgJuG85tPgVMlFVcDnJF4aX63y0ZaqnRvv5EB32kp1kaJ17Oedg.fIf22AkMIaL-BylAMNSw7Q.aLMcch8U-Wx-6Y9xPti5b-H63AthqlCihBLCBZvRYd476HyCAzvuGMGzvHOuPFgFaAsxzOWkWNULOtQB2TiE2wLwCatrU2yUgaUisfXUKq1Lw0AFXyZmqcot-RNlf8hucoFHp7e9AoflKGibHEie80xHgw04jxTT7B0Y_OhpSng1cWBd3AU7UwCFKOngUugdBZ2dOmZ2zyq1oYY5FDmhm4hfB0a05s7jwImsXLsYK1LLw7wBjSzKBCJZwR055T0NbsadK1ze3rbwmx9fEruANSDSwUxsapbv1nvFPGvf03Da7FPOztVaLEraRkhXQIq1oAV2sXgKS2nD8nsEsAzJqt1iARmkj0udwmdhpHdnpRBtFJNEAAfEJf8B3ZbwvD7k0HaWEupLIdnY0nqiYKfjDUB9oFAjFOTnjrjqMt4fI73Axh5BcG6n-wCYxF3zGPGLhV_wR8usG_JKIZIeyaVik7isGBEPnFW98RX1Te5TUDLG-J84QrwauTpMkv99h_fkuJI-m1TfOTDAN2mZcTpQyuCZFDDjaYArhSMTUHgx2XSffPS8QmV8LqWMgwodyfxbGEvhbr_jpECXMV5J_ZXuKA.tCM9AdCCGHwLHXxzec7wtg',
+        }, { nonce: '9cda9a61a2b01b31aa0b31d3c33631a1' });
+      });
+    });
+
+    describe('#callbackParams', function () {
+      before(function () {
+        const issuer = new Issuer({ issuer: 'http://localhost:3000/op' });
+        this.client = new issuer.Client({ client_id: 'client_id' });
+      });
+
+      before(function () {
+        this.origIncomingMessage = stdhttp.IncomingMessage;
+        stdhttp.IncomingMessage = MockRequest;
+      });
+
+      after(function () {
+        stdhttp.IncomingMessage = this.origIncomingMessage;
+      });
+
+      it('returns query params from full uri', function () {
+        expect(this.client.callbackParams('http://oidc-client.dev/cb?code=code')).to.eql({ code: 'code' });
+      });
+
+      it('returns query params from node request uri', function () {
+        expect(this.client.callbackParams('/cb?code=code')).to.eql({ code: 'code' });
+      });
+
+      it('works with IncomingMessage (GET + query)', function () {
+        const req = new MockRequest('GET', '/cb?code=code');
+        expect(this.client.callbackParams(req)).to.eql({ code: 'code' });
+      });
+
+      it('works with IncomingMessage (POST + pre-parsed string)', function () {
+        const req = new MockRequest('POST', '/cb', {
+          body: 'code=code',
+        });
+        expect(this.client.callbackParams(req)).to.eql({ code: 'code' });
+      });
+
+      it('works with IncomingMessage (POST + pre-parsed object)', function () {
+        const req = new MockRequest('POST', '/cb', {
+          body: { code: 'code' },
+        });
+        expect(this.client.callbackParams(req)).to.eql({ code: 'code' });
+      });
+
+      it('works with IncomingMessage (POST + pre-parsed buffer)', function () {
+        const req = new MockRequest('POST', '/cb', {
+          body: new Buffer('code=code'),
+        });
+        expect(this.client.callbackParams(req)).to.eql({ code: 'code' });
+      });
+
+      it('rejects nonbody parsed POSTs', function () {
+        const req = new MockRequest('POST', '/cb');
+        expect(() => {
+          this.client.callbackParams(req);
+        }).to.throw('incoming message body missing, include a body parser prior to this call');
+      });
+
+      it('rejects non-object,buffer,string parsed bodies', function () {
+        const req = new MockRequest('POST', '/cb', { body: true });
+        expect(() => {
+          this.client.callbackParams(req);
+        }).to.throw('invalid IncomingMessage body object');
+      });
+
+      it('rejects IncomingMessage other than GET, POST', function () {
+        const req = new MockRequest('PUT', '/cb', {
+          body: { code: 'code' },
+        });
+        expect(() => {
+          this.client.callbackParams(req);
+        }).to.throw('invalid IncomingMessage method');
+      });
+
+      it('fails for other than strings or IncomingMessage', function () {
+        expect(() => {
+          this.client.callbackParams({});
+        }).to.throw('#callbackParams only accepts string urls, http.IncomingMessage or a lookalike');
+        expect(() => {
+          this.client.callbackParams(true);
+        }).to.throw('#callbackParams only accepts string urls, http.IncomingMessage or a lookalike');
+        expect(() => {
+          this.client.callbackParams([]);
+        }).to.throw('#callbackParams only accepts string urls, http.IncomingMessage or a lookalike');
+      });
+    });
+
+    describe('#requestObject', function () {
+      before(function () {
+        this.keystore = jose.JWK.createKeyStore();
+        return this.keystore.generate('RSA', 512);
+      });
+
+      before(function () {
+        this.issuer = new Issuer({
+          issuer: 'https://op.example.com',
+          jwks_uri: 'https://op.example.com/certs',
+        });
+      });
+
+      before(function () {
+        nock('https://op.example.com')
+          .get('/certs')
+          .reply(200, this.keystore.toJSON());
+
+        return this.issuer.key();
+      });
+
+      after(nock.cleanAll);
+
+      it('sign alg=none', function () {
+        const client = new this.issuer.Client({ client_id: 'client_id', request_object_signing_alg: 'none' });
+
+        return client.requestObject({ state: 'foobar' })
+          .then((signed) => {
+            const parts = signed.split('.');
+            expect(JSON.parse(base64url.decode(parts[0]))).to.eql({ alg: 'none', typ: 'JWT' });
+            expect(JSON.parse(base64url.decode(parts[1]))).to.eql({
+              iss: 'client_id', client_id: 'client_id', aud: 'https://op.example.com', state: 'foobar',
+            });
+            expect(parts[2]).to.equal('');
+          });
+      });
+
+      it('sign alg=HSxxx', function () {
+        const client = new this.issuer.Client({ client_id: 'client_id', request_object_signing_alg: 'HS256', client_secret: 'atleast32byteslongforHS256mmkay?' });
+
+        return client.requestObject({ state: 'foobar' })
+          .then((signed) => {
+            const parts = signed.split('.');
+            expect(JSON.parse(base64url.decode(parts[0]))).to.eql({ alg: 'HS256', typ: 'JWT' });
+            expect(JSON.parse(base64url.decode(parts[1]))).to.eql({
+              iss: 'client_id', client_id: 'client_id', aud: 'https://op.example.com', state: 'foobar',
+            });
+            expect(parts[2].length).to.be.ok;
+          });
+      });
+
+      it('sign alg=RSxxx', function () {
+        const client = new this.issuer.Client({ client_id: 'client_id', request_object_signing_alg: 'RS256' }, this.keystore);
+
+        return client.requestObject({ state: 'foobar' })
+          .then((signed) => {
+            const parts = signed.split('.');
+            expect(JSON.parse(base64url.decode(parts[0]))).to.contain({ alg: 'RS256', typ: 'JWT' }).and.have.property('kid');
+            expect(JSON.parse(base64url.decode(parts[1]))).to.eql({
+              iss: 'client_id', client_id: 'client_id', aud: 'https://op.example.com', state: 'foobar',
+            });
+            expect(parts[2].length).to.be.ok;
+          });
+      });
+
+      it('encrypts for issuer using issuer\'s public key', function () {
+        const client = new this.issuer.Client({ client_id: 'client_id', request_object_encryption_alg: 'RSA1_5', request_object_encryption_enc: 'A128CBC-HS256' });
+
+        return client.requestObject({ state: 'foobar' })
+          .then((encrypted) => {
+            const parts = encrypted.split('.');
+            expect(JSON.parse(base64url.decode(parts[0]))).to.contain({ alg: 'RSA1_5', enc: 'A128CBC-HS256', cty: 'JWT' }).and.have.property('kid');
+          });
+      });
+
+      it('encrypts for issuer using pre-shared client_secret (PBES2)', function () {
+        const client = new this.issuer.Client({
+          client_id: 'client_id',
+          client_secret: 'GfsT479VMy5ZZZPquadPbN3wKzaFGYo1CTkb0IFFzDNODLEAuC2GUV3QsTye3xNQ',
+          request_object_encryption_alg: 'PBES2-HS256+A128KW',
+        });
+
+        return client.requestObject({ state: 'foobar' })
+          .then((encrypted) => {
+            const parts = encrypted.split('.');
+            expect(JSON.parse(base64url.decode(parts[0]))).to.contain({ alg: 'PBES2-HS256+A128KW', enc: 'A128CBC-HS256', cty: 'JWT' }).and.not.have.property('kid');
+          });
+      });
+
+      it('encrypts for issuer using pre-shared client_secret (A\\d{3}KW)', function () {
+        const client = new this.issuer.Client({
+          client_id: 'client_id',
+          client_secret: 'GfsT479VMy5ZZZPquadPbN3wKzaFGYo1CTkb0IFFzDNODLEAuC2GUV3QsTye3xNQ',
+          request_object_encryption_alg: 'A128KW',
+        });
+
+        return client.requestObject({ state: 'foobar' })
+          .then((encrypted) => {
+            const parts = encrypted.split('.');
+            expect(JSON.parse(base64url.decode(parts[0]))).to.contain({ alg: 'A128KW', enc: 'A128CBC-HS256', cty: 'JWT' }).and.not.have.property('kid');
+          });
+      });
     });
   });
 });

--- a/test/client/discover_client.test.js
+++ b/test/client/discover_client.test.js
@@ -7,55 +7,61 @@ const nock = require('nock');
 const fail = () => { throw new Error('expected promise to be rejected'); };
 const issuer = new Issuer();
 
-describe('Client#fromUri()', function () {
-  it('accepts and assigns the discovered metadata', function () {
-    nock('https://op.example.com')
-      .get('/client/identifier')
-      .reply(200, {
-        client_id: 'identifier',
-        client_secret: 'secure',
-      });
-
-    return issuer.Client.fromUri('https://op.example.com/client/identifier').then(function (client) {
-      expect(client).to.have.property('client_id', 'identifier');
-      expect(client).to.have.property('client_secret', 'secure');
+['useGot', 'useRequest'].forEach((httpProvider) => {
+  describe(`Client#fromUri() - using ${httpProvider.substring(3).toLowerCase()}`, function () {
+    before(function () {
+      Issuer[httpProvider]();
     });
-  });
 
-  it('is rejected with OpenIdConnectError upon oidc error', function () {
-    nock('https://op.example.com')
-      .get('/client/identifier')
-      .reply(500, {
-        error: 'server_error',
-        error_description: 'bad things are happening',
+    it('accepts and assigns the discovered metadata', function () {
+      nock('https://op.example.com')
+        .get('/client/identifier')
+        .reply(200, {
+          client_id: 'identifier',
+          client_secret: 'secure',
+        });
+
+      return issuer.Client.fromUri('https://op.example.com/client/identifier').then(function (client) {
+        expect(client).to.have.property('client_id', 'identifier');
+        expect(client).to.have.property('client_secret', 'secure');
       });
+    });
 
-    return issuer.Client.fromUri('https://op.example.com/client/identifier')
-      .then(fail, function (error) {
-        expect(error).to.have.property('message', 'server_error');
-      });
-  });
+    it('is rejected with OpenIdConnectError upon oidc error', function () {
+      nock('https://op.example.com')
+        .get('/client/identifier')
+        .reply(500, {
+          error: 'server_error',
+          error_description: 'bad things are happening',
+        });
 
-  it('is rejected with when non 200 is returned', function () {
-    nock('https://op.example.com')
-      .get('/client/identifier')
-      .reply(500, 'Internal Server Error');
+      return issuer.Client.fromUri('https://op.example.com/client/identifier')
+        .then(fail, function (error) {
+          expect(error).to.have.property('message', 'server_error');
+        });
+    });
 
-    return issuer.Client.fromUri('https://op.example.com/client/identifier')
-      .then(fail, function (error) {
-        expect(error).to.be.an.instanceof(issuer.httpClient.HTTPError);
-      });
-  });
+    it('is rejected with when non 200 is returned', function () {
+      nock('https://op.example.com')
+        .get('/client/identifier')
+        .reply(500, 'Internal Server Error');
 
-  it('is rejected with JSON.parse error upon invalid response', function () {
-    nock('https://op.example.com')
-      .get('/client/identifier')
-      .reply(200, '{"notavalid"}');
+      return issuer.Client.fromUri('https://op.example.com/client/identifier')
+        .then(fail, function (error) {
+          expect(error).to.be.an.instanceof(issuer.httpClient.HTTPError);
+        });
+    });
 
-    return issuer.Client.fromUri('https://op.example.com/client/identifier')
-      .then(fail, function (error) {
-        expect(error).to.be.an.instanceof(SyntaxError);
-        expect(error).to.have.property('message').matches(/Unexpected token/);
-      });
+    it('is rejected with JSON.parse error upon invalid response', function () {
+      nock('https://op.example.com')
+        .get('/client/identifier')
+        .reply(200, '{"notavalid"}');
+
+      return issuer.Client.fromUri('https://op.example.com/client/identifier')
+        .then(fail, function (error) {
+          expect(error).to.be.an.instanceof(SyntaxError);
+          expect(error).to.have.property('message').matches(/Unexpected token/);
+        });
+    });
   });
 });

--- a/test/client/register_client.test.js
+++ b/test/client/register_client.test.js
@@ -10,255 +10,261 @@ const issuer = new Issuer({
   registration_endpoint: 'https://op.example.com/client/registration',
 });
 
-describe('Client#register', function () {
-  afterEach(nock.cleanAll);
-
-  it('asserts the issuer has a registration endpoint', function () {
-    const issuer = new Issuer({}); // eslint-disable-line no-shadow
-    expect(function () {
-      issuer.Client.register();
-    }).to.throw('issuer does not support dynamic registration');
-  });
-
-  it('accepts and assigns the discovered metadata', function () {
-    nock('https://op.example.com')
-      .post('/client/registration')
-      .reply(200, {
-        client_id: 'identifier',
-        client_secret: 'secure',
-      });
-
-    return issuer.Client.register({}).then(function (client) {
-      expect(client).to.be.instanceof(issuer.Client);
-      expect(client).to.have.property('client_id', 'identifier');
-      expect(client).to.have.property('client_secret', 'secure');
+['useGot', 'useRequest'].forEach((httpProvider) => {
+  describe(`Client#register - using ${httpProvider.substring(3).toLowerCase()}`, function () {
+    before(function () {
+      Issuer[httpProvider]();
     });
-  });
 
-  it('is rejected with OpenIdConnectError upon oidc error', function () {
-    nock('https://op.example.com')
-      .post('/client/registration')
-      .reply(500, {
-        error: 'server_error',
-        error_description: 'bad things are happening',
-      });
+    afterEach(nock.cleanAll);
 
-    return issuer.Client.register({})
-      .then(fail, function (error) {
-        expect(error).to.have.property('message', 'server_error');
-      });
-  });
+    it('asserts the issuer has a registration endpoint', function () {
+      const issuer = new Issuer({}); // eslint-disable-line no-shadow
+      expect(function () {
+        issuer.Client.register();
+      }).to.throw('issuer does not support dynamic registration');
+    });
 
-  it('is rejected with when non 200 is returned', function () {
-    nock('https://op.example.com')
-      .post('/client/registration')
-      .reply(500, 'Internal Server Error');
-
-    return issuer.Client.register({})
-      .then(fail, function (error) {
-        expect(error).to.be.an.instanceof(issuer.httpClient.HTTPError);
-      });
-  });
-
-  it('is rejected with JSON.parse error upon invalid response', function () {
-    nock('https://op.example.com')
-      .post('/client/registration')
-      .reply(200, '{"notavalid"}');
-
-    return issuer.Client.register({})
-      .then(fail, function (error) {
-        expect(error).to.be.an.instanceof(SyntaxError);
-        expect(error).to.have.property('message').matches(/Unexpected token/);
-      });
-  });
-
-  context('with keystore (deprecated)', function () {
-    it('enriches the registration with jwks if not provided (or jwks_uri)', function () {
-      const keystore = jose.JWK.createKeyStore();
-
+    it('accepts and assigns the discovered metadata', function () {
       nock('https://op.example.com')
-        .filteringRequestBody(function (body) {
-          expect(JSON.parse(body)).to.eql({
-            jwks: keystore.toJSON(),
+        .post('/client/registration')
+        .reply(200, {
+          client_id: 'identifier',
+          client_secret: 'secure',
+        });
+
+      return issuer.Client.register({}).then(function (client) {
+        expect(client).to.be.instanceof(issuer.Client);
+        expect(client).to.have.property('client_id', 'identifier');
+        expect(client).to.have.property('client_secret', 'secure');
+      });
+    });
+
+    it('is rejected with OpenIdConnectError upon oidc error', function () {
+      nock('https://op.example.com')
+        .post('/client/registration')
+        .reply(500, {
+          error: 'server_error',
+          error_description: 'bad things are happening',
+        });
+
+      return issuer.Client.register({})
+        .then(fail, function (error) {
+          expect(error).to.have.property('message', 'server_error');
+        });
+    });
+
+    it('is rejected with when non 200 is returned', function () {
+      nock('https://op.example.com')
+        .post('/client/registration')
+        .reply(500, 'Internal Server Error');
+
+      return issuer.Client.register({})
+        .then(fail, function (error) {
+          expect(error).to.be.an.instanceof(issuer.httpClient.HTTPError);
+        });
+    });
+
+    it('is rejected with JSON.parse error upon invalid response', function () {
+      nock('https://op.example.com')
+        .post('/client/registration')
+        .reply(200, '{"notavalid"}');
+
+      return issuer.Client.register({})
+        .then(fail, function (error) {
+          expect(error).to.be.an.instanceof(SyntaxError);
+          expect(error).to.have.property('message').matches(/Unexpected token/);
+        });
+    });
+
+    context('with keystore (deprecated)', function () {
+      it('enriches the registration with jwks if not provided (or jwks_uri)', function () {
+        const keystore = jose.JWK.createKeyStore();
+
+        nock('https://op.example.com')
+          .filteringRequestBody(function (body) {
+            expect(JSON.parse(body)).to.eql({
+              jwks: keystore.toJSON(),
+            });
+          })
+          .post('/client/registration')
+          .reply(200, {
+            client_id: 'identifier',
+            client_secret: 'secure',
           });
-        })
-        .post('/client/registration')
-        .reply(200, {
-          client_id: 'identifier',
-          client_secret: 'secure',
-        });
 
-      return keystore.generate('EC', 'P-256').then(() => issuer.Client.register({}, keystore));
-    });
+        return keystore.generate('EC', 'P-256').then(() => issuer.Client.register({}, keystore));
+      });
 
-    it('ignores the keystore during registration if jwks is provided', function () {
-      const keystore = jose.JWK.createKeyStore();
+      it('ignores the keystore during registration if jwks is provided', function () {
+        const keystore = jose.JWK.createKeyStore();
 
-      nock('https://op.example.com')
-        .filteringRequestBody(function (body) {
-          expect(JSON.parse(body)).to.eql({
-            jwks: 'whatever',
+        nock('https://op.example.com')
+          .filteringRequestBody(function (body) {
+            expect(JSON.parse(body)).to.eql({
+              jwks: 'whatever',
+            });
+          })
+          .post('/client/registration')
+          .reply(200, {
+            client_id: 'identifier',
+            client_secret: 'secure',
           });
-        })
-        .post('/client/registration')
-        .reply(200, {
-          client_id: 'identifier',
-          client_secret: 'secure',
-        });
 
-      return keystore.generate('EC', 'P-256').then(() => issuer.Client.register({
-        jwks: 'whatever',
-      }, keystore));
-    });
+        return keystore.generate('EC', 'P-256').then(() => issuer.Client.register({
+          jwks: 'whatever',
+        }, keystore));
+      });
 
-    it('ignores the keystore during registration if jwks_uri is provided', function () {
-      const keystore = jose.JWK.createKeyStore();
+      it('ignores the keystore during registration if jwks_uri is provided', function () {
+        const keystore = jose.JWK.createKeyStore();
 
-      nock('https://op.example.com')
-        .filteringRequestBody(function (body) {
-          expect(JSON.parse(body)).to.eql({
-            jwks_uri: 'https://rp.example.com/certs',
+        nock('https://op.example.com')
+          .filteringRequestBody(function (body) {
+            expect(JSON.parse(body)).to.eql({
+              jwks_uri: 'https://rp.example.com/certs',
+            });
+          })
+          .post('/client/registration')
+          .reply(200, {
+            client_id: 'identifier',
+            client_secret: 'secure',
           });
-        })
-        .post('/client/registration')
-        .reply(200, {
-          client_id: 'identifier',
-          client_secret: 'secure',
+
+        return keystore.generate('EC', 'P-256').then(() => issuer.Client.register({
+          jwks_uri: 'https://rp.example.com/certs',
+        }, keystore));
+      });
+
+      it('does not accept oct keys', function () {
+        const keystore = jose.JWK.createKeyStore();
+
+        return keystore.generate('oct', 32).then(() => {
+          expect(function () {
+            issuer.Client.register({}, keystore);
+          }).to.throw('keystore must only contain private EC or RSA keys');
         });
+      });
 
-      return keystore.generate('EC', 'P-256').then(() => issuer.Client.register({
-        jwks_uri: 'https://rp.example.com/certs',
-      }, keystore));
-    });
-
-    it('does not accept oct keys', function () {
-      const keystore = jose.JWK.createKeyStore();
-
-      return keystore.generate('oct', 32).then(() => {
-        expect(function () {
-          issuer.Client.register({}, keystore);
-        }).to.throw('keystore must only contain private EC or RSA keys');
+      it('does not accept public keys', function () {
+        return jose.JWK.asKey({
+          kty: 'EC',
+          kid: 'MFZeG102dQiqbANoaMlW_Jmf7fOZmtRsHt77JFhTpF0',
+          crv: 'P-256',
+          x: 'FWZ9rSkLt6Dx9E3pxLybhdM6xgR5obGsj5_pqmnz5J4',
+          y: '_n8G69C-A2Xl4xUW2lF0i8ZGZnk_KPYrhv4GbTGu5G4',
+        }).then((key) => {
+          expect(function () {
+            issuer.Client.register({}, key.keystore);
+          }).to.throw('keystore must only contain private EC or RSA keys');
+        });
       });
     });
 
-    it('does not accept public keys', function () {
-      return jose.JWK.asKey({
-        kty: 'EC',
-        kid: 'MFZeG102dQiqbANoaMlW_Jmf7fOZmtRsHt77JFhTpF0',
-        crv: 'P-256',
-        x: 'FWZ9rSkLt6Dx9E3pxLybhdM6xgR5obGsj5_pqmnz5J4',
-        y: '_n8G69C-A2Xl4xUW2lF0i8ZGZnk_KPYrhv4GbTGu5G4',
-      }).then((key) => {
-        expect(function () {
-          issuer.Client.register({}, key.keystore);
-        }).to.throw('keystore must only contain private EC or RSA keys');
-      });
-    });
-  });
+    context('with keystore (as option)', function () {
+      it('enriches the registration with jwks if not provided (or jwks_uri)', function () {
+        const keystore = jose.JWK.createKeyStore();
 
-  context('with keystore (as option)', function () {
-    it('enriches the registration with jwks if not provided (or jwks_uri)', function () {
-      const keystore = jose.JWK.createKeyStore();
-
-      nock('https://op.example.com')
-        .filteringRequestBody(function (body) {
-          expect(JSON.parse(body)).to.eql({
-            jwks: keystore.toJSON(),
+        nock('https://op.example.com')
+          .filteringRequestBody(function (body) {
+            expect(JSON.parse(body)).to.eql({
+              jwks: keystore.toJSON(),
+            });
+          })
+          .post('/client/registration')
+          .reply(200, {
+            client_id: 'identifier',
+            client_secret: 'secure',
           });
-        })
-        .post('/client/registration')
-        .reply(200, {
-          client_id: 'identifier',
-          client_secret: 'secure',
-        });
 
-      return keystore.generate('EC', 'P-256').then(() => issuer.Client.register({}, { keystore }));
-    });
+        return keystore.generate('EC', 'P-256').then(() => issuer.Client.register({}, { keystore }));
+      });
 
-    it('ignores the keystore during registration if jwks is provided', function () {
-      const keystore = jose.JWK.createKeyStore();
+      it('ignores the keystore during registration if jwks is provided', function () {
+        const keystore = jose.JWK.createKeyStore();
 
-      nock('https://op.example.com')
-        .filteringRequestBody(function (body) {
-          expect(JSON.parse(body)).to.eql({
-            jwks: 'whatever',
+        nock('https://op.example.com')
+          .filteringRequestBody(function (body) {
+            expect(JSON.parse(body)).to.eql({
+              jwks: 'whatever',
+            });
+          })
+          .post('/client/registration')
+          .reply(200, {
+            client_id: 'identifier',
+            client_secret: 'secure',
           });
-        })
-        .post('/client/registration')
-        .reply(200, {
-          client_id: 'identifier',
-          client_secret: 'secure',
-        });
 
-      return keystore.generate('EC', 'P-256').then(() => issuer.Client.register({
-        jwks: 'whatever',
-      }, { keystore }));
-    });
+        return keystore.generate('EC', 'P-256').then(() => issuer.Client.register({
+          jwks: 'whatever',
+        }, { keystore }));
+      });
 
-    it('ignores the keystore during registration if jwks_uri is provided', function () {
-      const keystore = jose.JWK.createKeyStore();
+      it('ignores the keystore during registration if jwks_uri is provided', function () {
+        const keystore = jose.JWK.createKeyStore();
 
-      nock('https://op.example.com')
-        .filteringRequestBody(function (body) {
-          expect(JSON.parse(body)).to.eql({
-            jwks_uri: 'https://rp.example.com/certs',
+        nock('https://op.example.com')
+          .filteringRequestBody(function (body) {
+            expect(JSON.parse(body)).to.eql({
+              jwks_uri: 'https://rp.example.com/certs',
+            });
+          })
+          .post('/client/registration')
+          .reply(200, {
+            client_id: 'identifier',
+            client_secret: 'secure',
           });
-        })
-        .post('/client/registration')
-        .reply(200, {
-          client_id: 'identifier',
-          client_secret: 'secure',
+
+        return keystore.generate('EC', 'P-256').then(() => issuer.Client.register({
+          jwks_uri: 'https://rp.example.com/certs',
+        }, { keystore }));
+      });
+
+      it('validates it is a keystore', function () {
+        [{}, [], 'not a keystore', 2, true, false].forEach(function (notkeystore) {
+          expect(function () {
+            issuer.Client.register({}, { keystore: notkeystore });
+          }).to.throw('keystore must be an instance of jose.JWK.KeyStore');
         });
-
-      return keystore.generate('EC', 'P-256').then(() => issuer.Client.register({
-        jwks_uri: 'https://rp.example.com/certs',
-      }, { keystore }));
-    });
-
-    it('validates it is a keystore', function () {
-      [{}, [], 'not a keystore', 2, true, false].forEach(function (notkeystore) {
-        expect(function () {
-          issuer.Client.register({}, { keystore: notkeystore });
-        }).to.throw('keystore must be an instance of jose.JWK.KeyStore');
       });
-    });
 
-    it('does not accept oct keys', function () {
-      const keystore = jose.JWK.createKeyStore();
+      it('does not accept oct keys', function () {
+        const keystore = jose.JWK.createKeyStore();
 
-      return keystore.generate('oct', 32).then(() => {
-        expect(function () {
-          issuer.Client.register({}, { keystore });
-        }).to.throw('keystore must only contain private EC or RSA keys');
-      });
-    });
-
-    it('does not accept public keys', function () {
-      return jose.JWK.asKey({
-        kty: 'EC',
-        kid: 'MFZeG102dQiqbANoaMlW_Jmf7fOZmtRsHt77JFhTpF0',
-        crv: 'P-256',
-        x: 'FWZ9rSkLt6Dx9E3pxLybhdM6xgR5obGsj5_pqmnz5J4',
-        y: '_n8G69C-A2Xl4xUW2lF0i8ZGZnk_KPYrhv4GbTGu5G4',
-      }).then((key) => {
-        expect(function () {
-          issuer.Client.register({}, { keystore: key.keystore });
-        }).to.throw('keystore must only contain private EC or RSA keys');
-      });
-    });
-  });
-
-  context('with initialAccessToken (as option)', function () {
-    it('Uses the initialAccessToken in a Bearer authorization scheme', function () {
-      nock('https://op.example.com')
-        .matchHeader('authorization', 'Bearer foobar')
-        .post('/client/registration')
-        .reply(200, {
-          client_id: 'identifier',
-          client_secret: 'secure',
+        return keystore.generate('oct', 32).then(() => {
+          expect(function () {
+            issuer.Client.register({}, { keystore });
+          }).to.throw('keystore must only contain private EC or RSA keys');
         });
+      });
 
-      return issuer.Client.register({}, { initialAccessToken: 'foobar' });
+      it('does not accept public keys', function () {
+        return jose.JWK.asKey({
+          kty: 'EC',
+          kid: 'MFZeG102dQiqbANoaMlW_Jmf7fOZmtRsHt77JFhTpF0',
+          crv: 'P-256',
+          x: 'FWZ9rSkLt6Dx9E3pxLybhdM6xgR5obGsj5_pqmnz5J4',
+          y: '_n8G69C-A2Xl4xUW2lF0i8ZGZnk_KPYrhv4GbTGu5G4',
+        }).then((key) => {
+          expect(function () {
+            issuer.Client.register({}, { keystore: key.keystore });
+          }).to.throw('keystore must only contain private EC or RSA keys');
+        });
+      });
+    });
+
+    context('with initialAccessToken (as option)', function () {
+      it('Uses the initialAccessToken in a Bearer authorization scheme', function () {
+        nock('https://op.example.com')
+          .matchHeader('authorization', 'Bearer foobar')
+          .post('/client/registration')
+          .reply(200, {
+            client_id: 'identifier',
+            client_secret: 'secure',
+          });
+
+        return issuer.Client.register({}, { initialAccessToken: 'foobar' });
+      });
     });
   });
 });

--- a/test/issuer/discover_issuer.test.js
+++ b/test/issuer/discover_issuer.test.js
@@ -6,96 +6,102 @@ const nock = require('nock');
 
 const fail = () => { throw new Error('expected promise to be rejected'); };
 
-describe('Issuer#discover()', function () {
-  it('accepts and assigns the discovered metadata', function () {
-    nock('https://op.example.com')
-      .get('/.well-known/openid-configuration')
-      .reply(200, {
-        authorization_endpoint: 'https://op.example.com/o/oauth2/v2/auth',
-        issuer: 'https://op.example.com',
-        jwks_uri: 'https://op.example.com/oauth2/v3/certs',
-        token_endpoint: 'https://op.example.com/oauth2/v4/token',
-        userinfo_endpoint: 'https://op.example.com/oauth2/v3/userinfo',
-      });
-
-    return Issuer.discover('https://op.example.com/.well-known/openid-configuration').then(function (issuer) {
-      expect(issuer).to.have.property('authorization_endpoint', 'https://op.example.com/o/oauth2/v2/auth');
-      expect(issuer).to.have.property('issuer', 'https://op.example.com');
-      expect(issuer).to.have.property('jwks_uri', 'https://op.example.com/oauth2/v3/certs');
-      expect(issuer).to.have.property('token_endpoint', 'https://op.example.com/oauth2/v4/token');
-      expect(issuer).to.have.property('userinfo_endpoint', 'https://op.example.com/oauth2/v3/userinfo');
+['useGot', 'useRequest'].forEach((httpProvider) => {
+  describe(`Issuer#discover() - using ${httpProvider.substring(3).toLowerCase()}`, function () {
+    before(function () {
+      Issuer[httpProvider]();
     });
-  });
 
-  it('can be discovered by ommiting the well-known part', function () {
-    nock('https://op.example.com')
-      .get('/.well-known/openid-configuration')
-      .reply(200, {
-        issuer: 'https://op.example.com',
+    it('accepts and assigns the discovered metadata', function () {
+      nock('https://op.example.com')
+        .get('/.well-known/openid-configuration')
+        .reply(200, {
+          authorization_endpoint: 'https://op.example.com/o/oauth2/v2/auth',
+          issuer: 'https://op.example.com',
+          jwks_uri: 'https://op.example.com/oauth2/v3/certs',
+          token_endpoint: 'https://op.example.com/oauth2/v4/token',
+          userinfo_endpoint: 'https://op.example.com/oauth2/v3/userinfo',
+        });
+
+      return Issuer.discover('https://op.example.com/.well-known/openid-configuration').then(function (issuer) {
+        expect(issuer).to.have.property('authorization_endpoint', 'https://op.example.com/o/oauth2/v2/auth');
+        expect(issuer).to.have.property('issuer', 'https://op.example.com');
+        expect(issuer).to.have.property('jwks_uri', 'https://op.example.com/oauth2/v3/certs');
+        expect(issuer).to.have.property('token_endpoint', 'https://op.example.com/oauth2/v4/token');
+        expect(issuer).to.have.property('userinfo_endpoint', 'https://op.example.com/oauth2/v3/userinfo');
       });
-
-    return Issuer.discover('https://op.example.com').then(function (issuer) {
-      expect(issuer).to.have.property('issuer', 'https://op.example.com');
     });
-  });
 
-  it('discovering issuers with path components', function () {
-    nock('https://op.example.com')
-      .get('/oidc/.well-known/openid-configuration')
-      .reply(200, {
-        issuer: 'https://op.example.com/oidc',
+    it('can be discovered by ommiting the well-known part', function () {
+      nock('https://op.example.com')
+        .get('/.well-known/openid-configuration')
+        .reply(200, {
+          issuer: 'https://op.example.com',
+        });
+
+      return Issuer.discover('https://op.example.com').then(function (issuer) {
+        expect(issuer).to.have.property('issuer', 'https://op.example.com');
       });
-
-    return Issuer.discover('https://op.example.com/oidc/').then(function (issuer) {
-      expect(issuer).to.have.property('issuer', 'https://op.example.com/oidc');
     });
-  });
 
-  it('is rejected with OpenIdConnectError upon oidc error', function () {
-    nock('https://op.example.com')
-      .get('/.well-known/openid-configuration')
-      .reply(500, {
-        error: 'server_error',
-        error_description: 'bad things are happening',
+    it('discovering issuers with path components', function () {
+      nock('https://op.example.com')
+        .get('/oidc/.well-known/openid-configuration')
+        .reply(200, {
+          issuer: 'https://op.example.com/oidc',
+        });
+
+      return Issuer.discover('https://op.example.com/oidc/').then(function (issuer) {
+        expect(issuer).to.have.property('issuer', 'https://op.example.com/oidc');
       });
+    });
 
-    return Issuer.discover('https://op.example.com')
-      .then(fail, function (error) {
-        expect(error).to.have.property('message', 'server_error');
-      });
-  });
+    it('is rejected with OpenIdConnectError upon oidc error', function () {
+      nock('https://op.example.com')
+        .get('/.well-known/openid-configuration')
+        .reply(500, {
+          error: 'server_error',
+          error_description: 'bad things are happening',
+        });
 
-  it('is rejected with when non 200 is returned', function () {
-    nock('https://op.example.com')
-      .get('/.well-known/openid-configuration')
-      .reply(500, 'Internal Server Error');
+      return Issuer.discover('https://op.example.com')
+        .then(fail, function (error) {
+          expect(error).to.have.property('message', 'server_error');
+        });
+    });
 
-    return Issuer.discover('https://op.example.com')
-      .then(fail, function (error) {
-        expect(error).to.be.an.instanceof(Issuer.httpClient.HTTPError);
-      });
-  });
+    it('is rejected with when non 200 is returned', function () {
+      nock('https://op.example.com')
+        .get('/.well-known/openid-configuration')
+        .reply(500, 'Internal Server Error');
 
-  it('is rejected with JSON.parse error upon invalid response', function () {
-    nock('https://op.example.com')
-      .get('/.well-known/openid-configuration')
-      .reply(200, '{"notavalid"}');
+      return Issuer.discover('https://op.example.com')
+        .then(fail, function (error) {
+          expect(error).to.be.an.instanceof(Issuer.httpClient.HTTPError);
+        });
+    });
 
-    return Issuer.discover('https://op.example.com')
-      .then(fail, function (error) {
-        expect(error).to.be.an.instanceof(SyntaxError);
-        expect(error).to.have.property('message').matches(/Unexpected token/);
-      });
-  });
+    it('is rejected with JSON.parse error upon invalid response', function () {
+      nock('https://op.example.com')
+        .get('/.well-known/openid-configuration')
+        .reply(200, '{"notavalid"}');
 
-  it('is rejected when no body is returned', function () {
-    nock('https://op.example.com')
-      .get('/.well-known/openid-configuration')
-      .reply(301);
+      return Issuer.discover('https://op.example.com')
+        .then(fail, function (error) {
+          expect(error).to.be.an.instanceof(SyntaxError);
+          expect(error).to.have.property('message').matches(/Unexpected token/);
+        });
+    });
 
-    return Issuer.discover('https://op.example.com')
-      .then(fail, function (error) {
-        expect(error).to.have.property('message', 'expected 200 OK with body, got 301 Moved Permanently without one');
-      });
+    it('is rejected when no body is returned', function () {
+      nock('https://op.example.com')
+        .get('/.well-known/openid-configuration')
+        .reply(301);
+
+      return Issuer.discover('https://op.example.com')
+        .then(fail, function (error) {
+          expect(error).to.have.property('message', 'expected 200 OK with body, got 301 Moved Permanently without one');
+        });
+    });
   });
 });

--- a/test/issuer/discover_webfinger.test.js
+++ b/test/issuer/discover_webfinger.test.js
@@ -7,189 +7,195 @@ const nock = require('nock');
 
 const fail = () => { throw new Error('expected promise to be rejected'); };
 
-describe('Issuer#webfinger()', function () {
-  it('can discover using the EMAIL syntax', function () {
-    const webfinger = nock('https://opemail.example.com')
-      .get('/.well-known/webfinger')
-      .query(function (query) {
-        expect(query).to.have.property('resource', 'acct:joe@opemail.example.com');
-        return true;
-      })
-      .reply(200, {
-        subject: 'https://opemail.example.com/joe',
-        links: [
-          {
-            rel: 'http://openid.net/specs/connect/1.0/issuer',
-            href: 'https://opemail.example.com',
-          },
-        ],
-      });
-    const discovery = nock('https://opemail.example.com')
-      .get('/.well-known/openid-configuration')
-      .reply(200, {
-        authorization_endpoint: 'https://opemail.example.com/o/oauth2/v2/auth',
-        issuer: 'https://opemail.example.com',
-        jwks_uri: 'https://opemail.example.com/oauth2/v3/certs',
-        token_endpoint: 'https://opemail.example.com/oauth2/v4/token',
-        userinfo_endpoint: 'https://opemail.example.com/oauth2/v3/userinfo',
-      });
-
-    return Issuer.webfinger('joe@opemail.example.com').then(function () {
-      expect(webfinger.isDone()).to.be.true;
-      expect(discovery.isDone()).to.be.true;
+['useGot', 'useRequest'].forEach((httpProvider) => {
+  describe(`Issuer#webfinger() - using ${httpProvider.substring(3).toLowerCase()}`, function () {
+    before(function () {
+      Issuer[httpProvider]();
     });
-  });
 
-  it('uses cached issuer if it has one', function () {
-    const webfinger = nock('https://opemail.example.com')
-      .get('/.well-known/webfinger')
-      .query(function (query) {
-        expect(query).to.have.property('resource', 'acct:joe@opemail.example.com');
-        return true;
-      })
-      .reply(200, {
-        subject: 'https://opemail.example.com/joe',
-        links: [
-          {
-            rel: 'http://openid.net/specs/connect/1.0/issuer',
-            href: 'https://opemail.example.com',
-          },
-        ],
+    it('can discover using the EMAIL syntax', function () {
+      const webfinger = nock('https://opemail.example.com')
+        .get('/.well-known/webfinger')
+        .query(function (query) {
+          expect(query).to.have.property('resource', 'acct:joe@opemail.example.com');
+          return true;
+        })
+        .reply(200, {
+          subject: 'https://opemail.example.com/joe',
+          links: [
+            {
+              rel: 'http://openid.net/specs/connect/1.0/issuer',
+              href: 'https://opemail.example.com',
+            },
+          ],
+        });
+      const discovery = nock('https://opemail.example.com')
+        .get('/.well-known/openid-configuration')
+        .reply(200, {
+          authorization_endpoint: 'https://opemail.example.com/o/oauth2/v2/auth',
+          issuer: 'https://opemail.example.com',
+          jwks_uri: 'https://opemail.example.com/oauth2/v3/certs',
+          token_endpoint: 'https://opemail.example.com/oauth2/v4/token',
+          userinfo_endpoint: 'https://opemail.example.com/oauth2/v3/userinfo',
+        });
+
+      return Issuer.webfinger('joe@opemail.example.com').then(function () {
+        expect(webfinger.isDone()).to.be.true;
+        expect(discovery.isDone()).to.be.true;
       });
-
-    return Issuer.webfinger('joe@opemail.example.com').then(function () {
-      expect(webfinger.isDone()).to.be.true;
     });
-  });
 
-  it('validates the discovered issuer is the same as from webfinger', function () {
-    Registry.clear();
-    const webfinger = nock('https://op.example.com')
-      .get('/.well-known/webfinger')
-      .query(function (query) {
-        expect(query).to.have.property('resource', 'acct:joe@op.example.com');
-        return true;
-      })
-      .reply(200, {
-        subject: 'https://op.example.com/joe',
-        links: [
-          {
-            rel: 'http://openid.net/specs/connect/1.0/issuer',
-            href: 'https://op.example.com',
-          },
-        ],
-      });
-    const discovery = nock('https://op.example.com')
-      .get('/.well-known/openid-configuration')
-      .reply(200, {
-        authorization_endpoint: 'https://op.example.com/o/oauth2/v2/auth',
-        issuer: 'https://another.op.example.com',
-        jwks_uri: 'https://op.example.com/oauth2/v3/certs',
-        token_endpoint: 'https://op.example.com/oauth2/v4/token',
-        userinfo_endpoint: 'https://op.example.com/oauth2/v3/userinfo',
-      });
+    it('uses cached issuer if it has one', function () {
+      const webfinger = nock('https://opemail.example.com')
+        .get('/.well-known/webfinger')
+        .query(function (query) {
+          expect(query).to.have.property('resource', 'acct:joe@opemail.example.com');
+          return true;
+        })
+        .reply(200, {
+          subject: 'https://opemail.example.com/joe',
+          links: [
+            {
+              rel: 'http://openid.net/specs/connect/1.0/issuer',
+              href: 'https://opemail.example.com',
+            },
+          ],
+        });
 
-    return Issuer.webfinger('joe@op.example.com').then(fail, function (error) {
-      expect(webfinger.isDone()).to.be.true;
-      expect(discovery.isDone()).to.be.true;
-      expect(error.message).to.equal('discovered issuer mismatch');
-      expect(Registry.has('https://another.op.example.com')).to.be.false;
+      return Issuer.webfinger('joe@opemail.example.com').then(function () {
+        expect(webfinger.isDone()).to.be.true;
+      });
     });
-  });
 
-  it('can discover using the URL syntax', function () {
-    const webfinger = nock('https://opurl.example.com')
-      .get('/.well-known/webfinger')
-      .query(function (query) {
-        expect(query).to.have.property('resource', 'https://opurl.example.com/joe');
-        return true;
-      })
-      .reply(200, {
-        subject: 'https://opurl.example.com/joe',
-        links: [
-          {
-            rel: 'http://openid.net/specs/connect/1.0/issuer',
-            href: 'https://opurl.example.com',
-          },
-        ],
-      });
-    const discovery = nock('https://opurl.example.com')
-      .get('/.well-known/openid-configuration')
-      .reply(200, {
-        authorization_endpoint: 'https://opurl.example.com/o/oauth2/v2/auth',
-        issuer: 'https://opurl.example.com',
-        jwks_uri: 'https://opurl.example.com/oauth2/v3/certs',
-        token_endpoint: 'https://opurl.example.com/oauth2/v4/token',
-        userinfo_endpoint: 'https://opurl.example.com/oauth2/v3/userinfo',
-      });
+    it('validates the discovered issuer is the same as from webfinger', function () {
+      Registry.clear();
+      const webfinger = nock('https://op.example.com')
+        .get('/.well-known/webfinger')
+        .query(function (query) {
+          expect(query).to.have.property('resource', 'acct:joe@op.example.com');
+          return true;
+        })
+        .reply(200, {
+          subject: 'https://op.example.com/joe',
+          links: [
+            {
+              rel: 'http://openid.net/specs/connect/1.0/issuer',
+              href: 'https://op.example.com',
+            },
+          ],
+        });
+      const discovery = nock('https://op.example.com')
+        .get('/.well-known/openid-configuration')
+        .reply(200, {
+          authorization_endpoint: 'https://op.example.com/o/oauth2/v2/auth',
+          issuer: 'https://another.op.example.com',
+          jwks_uri: 'https://op.example.com/oauth2/v3/certs',
+          token_endpoint: 'https://op.example.com/oauth2/v4/token',
+          userinfo_endpoint: 'https://op.example.com/oauth2/v3/userinfo',
+        });
 
-    return Issuer.webfinger('https://opurl.example.com/joe').then(function () {
-      expect(webfinger.isDone()).to.be.true;
-      expect(discovery.isDone()).to.be.true;
+      return Issuer.webfinger('joe@op.example.com').then(fail, function (error) {
+        expect(webfinger.isDone()).to.be.true;
+        expect(discovery.isDone()).to.be.true;
+        expect(error.message).to.equal('discovered issuer mismatch');
+        expect(Registry.has('https://another.op.example.com')).to.be.false;
+      });
     });
-  });
 
-  it('can discover using the Hostname and Port syntax', function () {
-    const webfinger = nock('https://ophp.example.com:8080')
-      .get('/.well-known/webfinger')
-      .query(function (query) {
-        expect(query).to.have.property('resource', 'https://ophp.example.com:8080');
-        return true;
-      })
-      .reply(200, {
-        subject: 'https://example.com:8080',
-        links: [
-          {
-            rel: 'http://openid.net/specs/connect/1.0/issuer',
-            href: 'https://ophp.example.com',
-          },
-        ],
-      });
-    const discovery = nock('https://ophp.example.com')
-      .get('/.well-known/openid-configuration')
-      .reply(200, {
-        authorization_endpoint: 'https://ophp.example.com/o/oauth2/v2/auth',
-        issuer: 'https://ophp.example.com',
-        jwks_uri: 'https://ophp.example.com/oauth2/v3/certs',
-        token_endpoint: 'https://ophp.example.com/oauth2/v4/token',
-        userinfo_endpoint: 'https://ophp.example.com/oauth2/v3/userinfo',
-      });
+    it('can discover using the URL syntax', function () {
+      const webfinger = nock('https://opurl.example.com')
+        .get('/.well-known/webfinger')
+        .query(function (query) {
+          expect(query).to.have.property('resource', 'https://opurl.example.com/joe');
+          return true;
+        })
+        .reply(200, {
+          subject: 'https://opurl.example.com/joe',
+          links: [
+            {
+              rel: 'http://openid.net/specs/connect/1.0/issuer',
+              href: 'https://opurl.example.com',
+            },
+          ],
+        });
+      const discovery = nock('https://opurl.example.com')
+        .get('/.well-known/openid-configuration')
+        .reply(200, {
+          authorization_endpoint: 'https://opurl.example.com/o/oauth2/v2/auth',
+          issuer: 'https://opurl.example.com',
+          jwks_uri: 'https://opurl.example.com/oauth2/v3/certs',
+          token_endpoint: 'https://opurl.example.com/oauth2/v4/token',
+          userinfo_endpoint: 'https://opurl.example.com/oauth2/v3/userinfo',
+        });
 
-    return Issuer.webfinger('ophp.example.com:8080').then(function () {
-      expect(webfinger.isDone()).to.be.true;
-      expect(discovery.isDone()).to.be.true;
+      return Issuer.webfinger('https://opurl.example.com/joe').then(function () {
+        expect(webfinger.isDone()).to.be.true;
+        expect(discovery.isDone()).to.be.true;
+      });
     });
-  });
 
-  it('can discover using the acct syntax', function () {
-    const webfinger = nock('https://opacct.example.com')
-      .get('/.well-known/webfinger')
-      .query(function (query) {
-        expect(query).to.have.property('resource', 'acct:juliet%40capulet.example@opacct.example.com');
-        return true;
-      })
-      .reply(200, {
-        subject: 'acct:juliet%40capulet.example@opacct.example.com',
-        links: [
-          {
-            rel: 'http://openid.net/specs/connect/1.0/issuer',
-            href: 'https://opacct.example.com',
-          },
-        ],
-      });
-    const discovery = nock('https://opacct.example.com')
-      .get('/.well-known/openid-configuration')
-      .reply(200, {
-        authorization_endpoint: 'https://opacct.example.com/o/oauth2/v2/auth',
-        issuer: 'https://opacct.example.com',
-        jwks_uri: 'https://opacct.example.com/oauth2/v3/certs',
-        token_endpoint: 'https://opacct.example.com/oauth2/v4/token',
-        userinfo_endpoint: 'https://opacct.example.com/oauth2/v3/userinfo',
-      });
+    it('can discover using the Hostname and Port syntax', function () {
+      const webfinger = nock('https://ophp.example.com:8080')
+        .get('/.well-known/webfinger')
+        .query(function (query) {
+          expect(query).to.have.property('resource', 'https://ophp.example.com:8080');
+          return true;
+        })
+        .reply(200, {
+          subject: 'https://example.com:8080',
+          links: [
+            {
+              rel: 'http://openid.net/specs/connect/1.0/issuer',
+              href: 'https://ophp.example.com',
+            },
+          ],
+        });
+      const discovery = nock('https://ophp.example.com')
+        .get('/.well-known/openid-configuration')
+        .reply(200, {
+          authorization_endpoint: 'https://ophp.example.com/o/oauth2/v2/auth',
+          issuer: 'https://ophp.example.com',
+          jwks_uri: 'https://ophp.example.com/oauth2/v3/certs',
+          token_endpoint: 'https://ophp.example.com/oauth2/v4/token',
+          userinfo_endpoint: 'https://ophp.example.com/oauth2/v3/userinfo',
+        });
 
-    return Issuer.webfinger('acct:juliet%40capulet.example@opacct.example.com').then(function () {
-      expect(webfinger.isDone()).to.be.true;
-      expect(discovery.isDone()).to.be.true;
+      return Issuer.webfinger('ophp.example.com:8080').then(function () {
+        expect(webfinger.isDone()).to.be.true;
+        expect(discovery.isDone()).to.be.true;
+      });
+    });
+
+    it('can discover using the acct syntax', function () {
+      const webfinger = nock('https://opacct.example.com')
+        .get('/.well-known/webfinger')
+        .query(function (query) {
+          expect(query).to.have.property('resource', 'acct:juliet%40capulet.example@opacct.example.com');
+          return true;
+        })
+        .reply(200, {
+          subject: 'acct:juliet%40capulet.example@opacct.example.com',
+          links: [
+            {
+              rel: 'http://openid.net/specs/connect/1.0/issuer',
+              href: 'https://opacct.example.com',
+            },
+          ],
+        });
+      const discovery = nock('https://opacct.example.com')
+        .get('/.well-known/openid-configuration')
+        .reply(200, {
+          authorization_endpoint: 'https://opacct.example.com/o/oauth2/v2/auth',
+          issuer: 'https://opacct.example.com',
+          jwks_uri: 'https://opacct.example.com/oauth2/v3/certs',
+          token_endpoint: 'https://opacct.example.com/oauth2/v4/token',
+          userinfo_endpoint: 'https://opacct.example.com/oauth2/v3/userinfo',
+        });
+
+      return Issuer.webfinger('acct:juliet%40capulet.example@opacct.example.com').then(function () {
+        expect(webfinger.isDone()).to.be.true;
+        expect(discovery.isDone()).to.be.true;
+      });
     });
   });
 });


### PR DESCRIPTION
### Proxy settings / Use Request instead of Got
Because of the lightweight nature of got library the client will not use
environment-defined http(s) proxies. In order to have them used you'll need to either provide your own http request
implementation using the provided `httpClient` setter or use the bundled request
one.

Custom implementation:
```js
/*
 * url {String}
 * options {Object}
 * options.headers {Object}
 * options.body {String|Object}
 * options.form {Boolean}
 * options.query {Object}
 * options.timeout {Number}
 * options.retries {Number}
 * options.followRedirect {Boolean}
 */

Issuer.httpClient = {
   get(url, options) {}, // return Promise
   post(url, options) {}, // return Promise
   HTTPError, // used error constructor
};
```

Bundled (and maintained + tested) request implementation after you've added request
to your package.json bundle:

```
npm install request@^2.0.0 --save
```

```js
Issuer.useRequest();
```