### PR TITLE
Support for query parameters in defined authorization endpoint

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -221,10 +221,14 @@ class Client {
    */
   authorizationUrl(params) {
     assert(this.issuer.authorization_endpoint, 'authorization_endpoint must be configured');
+    const urlParsed = url.parse(this.issuer.authorization_endpoint);
     return url.format(_.defaults({
       search: null,
-      query: authorizationParams.call(this, params),
-    }, url.parse(this.issuer.authorization_endpoint)));
+      query: _.defaults(
+        authorizationParams.call(this, params),
+        urlParsed.query ? querystring.parse(urlParsed.query) : {}
+      ),
+    }, urlParsed));
   }
 
   /**

--- a/test/client/client_instance.test.js
+++ b/test/client/client_instance.test.js
@@ -39,6 +39,13 @@ const encode = object => base64url.encode(JSON.stringify(object));
         this.client = new issuer.Client({
           client_id: 'identifier',
         });
+
+        const issuerWithQuery = new Issuer({
+          authorization_endpoint: 'https://op.example.com/auth?a=b'
+        });
+        this.clientWithQuery = new issuerWithQuery.Client({
+          client_id: 'identifier',
+        });
       });
 
       it('returns a string with the url with some basic defaults', function () {
@@ -49,6 +56,18 @@ const encode = object => base64url.encode(JSON.stringify(object));
           redirect_uri: 'https://rp.example.com/cb',
           response_type: 'code',
           scope: 'openid',
+        });
+      });
+
+      it('keeps origin query parameters', function() {
+        expect(url.parse(this.clientWithQuery.authorizationUrl({
+          redirect_uri: 'https://rp.example.com/cb',
+        }), true).query).to.eql({
+          client_id: 'identifier',
+          redirect_uri: 'https://rp.example.com/cb',
+          response_type: 'code',
+          scope: 'openid',
+          a: 'b',
         });
       });
 


### PR DESCRIPTION
Query parameters on `authorization_endpoint` defined on Issuer were ignored when forming `authorizationUrl`.