### PR TITLE
fix basic auth to conform with rfc6749 2.3.1

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -797,6 +797,14 @@ class Client {
   }
 
   /**
+   * @name formUrlEncode
+   * @api private
+   */
+  formUrlEncode(value) {
+    return encodeURIComponent(value).replace(/%20/g, '+');
+  }
+
+   /**
    * @name authFor
    * @api private
    */
@@ -835,7 +843,8 @@ class Client {
         }));
       }
       default: {
-        const value = Buffer.from(`${this.client_id}:${this.client_secret}`).toString('base64');
+        const encoded = `${this.formUrlEncode(this.client_id)}:${this.formUrlEncode(this.client_secret)}`;
+        const value = Buffer.from(encoded).toString('base64');
         return { headers: { Authorization: `Basic ${value}` } };
       }
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -23,6 +23,10 @@ const issuerRegistry = require('./issuer_registry');
 const map = new WeakMap();
 const format = 'compact';
 
+function formUrlEncode(value) {
+  return encodeURIComponent(value).replace(/%20/g, '+');
+}
+
 function bearer(token) {
   return `Bearer ${token}`;
 }
@@ -797,14 +801,6 @@ class Client {
   }
 
   /**
-   * @name formUrlEncode
-   * @api private
-   */
-  formUrlEncode(value) {
-    return encodeURIComponent(value).replace(/%20/g, '+');
-  }
-
-   /**
    * @name authFor
    * @api private
    */
@@ -843,7 +839,7 @@ class Client {
         }));
       }
       default: {
-        const encoded = `${this.formUrlEncode(this.client_id)}:${this.formUrlEncode(this.client_secret)}`;
+        const encoded = `${formUrlEncode(this.client_id)}:${formUrlEncode(this.client_secret)}`;
         const value = Buffer.from(encoded).toString('base64');
         return { headers: { Authorization: `Basic ${value}` } };
       }

--- a/test/client/client_instance.test.js
+++ b/test/client/client_instance.test.js
@@ -926,6 +926,13 @@ const encode = object => base64url.encode(JSON.stringify(object));
             headers: { Authorization: 'Basic aWRlbnRpZmllcjpzZWN1cmU=' },
           });
         });
+
+        it('works with non-text characters', function () {
+          const client = new Client({ client_id: 'an:identifier', client_secret: 'some secure & non-standard secret' });
+          expect(client.authFor('token')).to.eql({
+            headers: { Authorization: 'Basic YW4lM0FpZGVudGlmaWVyOnNvbWUrc2VjdXJlKyUyNitub24tc3RhbmRhcmQrc2VjcmV0' },
+          });
+        });
       });
 
       context('when client_secret_jwt', function () {


### PR DESCRIPTION
The purpose of this PR is to fix compliance with [rfc6749 2.3.1](https://tools.ietf.org/html/rfc6749#section-2.3.1), specifically [Appendix B](https://tools.ietf.org/html/rfc6749#appendix-B). 

This library currently implements the Basic authentication scheme, but not the additional requirement of url-encoding both the username and password portion before base64 encoding the whole thing. 

There was a recent [fix](https://github.com/IdentityServer/IdentityServer4/issues/2039) in IdentityServer4 that prompted the discovery of this issue.

A similar implementation can be found [here](https://github.com/lelylan/simple-oauth2/blob/master/lib/encoding.js).