### PR TITLE
Add the ability to dynamically copy querystring parameters with passport strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ const params = {
   // redirect_uri defaults to client.redirect_uris[0]
   // response type defaults to client.response_types[0], then 'code'
   // scope defaults to 'openid'
+  // copyParams truthy to copy all querystring parameters from the request, or an array containing specific names to copy
 }
 const passReqToCallback = false; // optional, defaults to false, when true req is passed as a first
                                  // argument to verify fn

--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -9,6 +9,7 @@ const url = require('url');
 const assert = require('assert');
 const OpenIdConnectError = require('./open_id_connect_error');
 const Client = require('./client');
+const { URL } = require('url');
 
 function verified(err, user, info = {}) {
   if (err) {
@@ -30,6 +31,7 @@ function OpenIDConnectStrategy({
   passReqToCallback = false,
   sessionKey,
   usePKCE = false,
+  copyParams = false,
 } = {}, verify) {
   assert(client instanceof Client, 'client must be an instance of openid-client Client');
   assert.equal(typeof verify, 'function', 'verify must be a function');
@@ -43,6 +45,7 @@ function OpenIDConnectStrategy({
   this._usePKCE = usePKCE;
   this._key = sessionKey || `oidc:${url.parse(this._issuer.issuer).hostname}`;
   this._params = params;
+  this._copyParams = copyParams;
 
   if (this._usePKCE === true) {
     const supportedMethods = this._issuer.code_challenge_methods_supported;
@@ -103,7 +106,21 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
         }
       }
 
-      this.redirect(client.authorizationUrl(params));
+      let authUrl = client.authorizationUrl(params);
+      if (this._copyParams) {
+        const urlObj = new URL(authUrl);
+        const copyParams = this._copyParams;
+        if (req.query) {
+          Object.keys(req.query).forEach((key) => {
+            if (!Array.isArray(copyParams) || copyParams.includes(key)) {
+              urlObj.searchParams.set(key, req.query[key]);
+            }
+          });
+        }
+        authUrl = urlObj.toString();
+      }
+
+      this.redirect(authUrl);
       return;
     }
     /* end authentication request */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openid-client",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "OpenID Connect Relying Party (RP, Client) implementation for Node.js servers, supports passportjs",
   "keywords": [
     "auth",

--- a/test/passport/passport_strategy.test.js
+++ b/test/passport/passport_strategy.test.js
@@ -135,6 +135,16 @@ const { Issuer, Strategy } = require('../../lib');
         expect(req.session).to.have.property('oidc:op.example.com');
         expect(req.session['oidc:op.example.com']).to.have.keys('state');
       });
+      it('should handle a request without a query object if copyParams is truthy', function () {
+        const strategy = new Strategy({ client: this.client, copyParams: ['foo'] }, () => {});
+
+        const req = new MockRequest('POST', '/login/oidc');
+        req.session = {};
+        req.body = {};
+
+        strategy.redirect = sinon.spy();
+        expect(() => strategy.authenticate(req)).not.to.throw();
+      });
       it('can have redirect_uri and scope specified', function () {
         const strategy = new Strategy({
           client: this.client,
@@ -155,7 +165,6 @@ const { Issuer, Strategy } = require('../../lib');
         expect(target).to.include(`redirect_uri=${encodeURIComponent('https://example.com/cb')}`);
         expect(target).to.include('scope=openid%20profile');
       });
-
       it('automatically includes nonce for where it applies', function () {
         const strategy = new Strategy({
           client: this.client,


### PR DESCRIPTION
Added an additional option to the Passport strategy "copyParams" which will copy all querystring parameters to the authorization URI if it is truthy or, if it is an array, copy any parameters whose names exist in the array.