### PR TITLE
fix: stop sending state on the authorisation code token grant

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -376,7 +376,6 @@ class Client {
         code: params.code,
         redirect_uri: redirectUri,
         code_verifier: checks.code_verifier,
-        state: checks.state,
       })
         .then(tokenset => this.decryptIdToken(tokenset))
         .then(tokenset => this.validateIdToken(tokenset, checks.nonce, 'token', checks.max_age))


### PR DESCRIPTION
This was added a long time ago as it was recommended by
an early ‘mix-up mitigation’ draft. It is now no longer the
recommended option as evidenced by the latest ‘oauth
security topics’ BCP.

This fixes issue #120 

NB - no tests were required to be changed