### PR TITLE
feat: add support for s_hash verification at token endpoint

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -378,7 +378,7 @@ class Client {
         code_verifier: checks.code_verifier,
       })
         .then(tokenset => this.decryptIdToken(tokenset))
-        .then(tokenset => this.validateIdToken(tokenset, checks.nonce, 'token', checks.max_age))
+        .then(tokenset => this.validateIdToken(tokenset, checks.nonce, 'token', checks.max_age, checks.state))
         .then((tokenset) => {
           if (params.session_state) tokenset.session_state = params.session_state;
           return tokenset;
@@ -581,11 +581,11 @@ class Client {
     if (returnedBy === 'authorization') {
       assert(payload.at_hash || !tokenSet.access_token, 'missing required property at_hash');
       assert(payload.c_hash || !tokenSet.code, 'missing required property c_hash');
+    }
 
-      if (payload.s_hash) {
-        assert(state, 'cannot verify s_hash, state not provided');
-        assert(tokenHash(payload.s_hash, state, header.alg), 's_hash mismatch');
-      }
+    if ((returnedBy === 'authorization' || returnedBy === 'token') && payload.s_hash) {
+      assert(state, 'cannot verify s_hash, state not provided');
+      assert(tokenHash(payload.s_hash, state, header.alg), 's_hash mismatch');
     }
 
     if (tokenSet.access_token && payload.at_hash !== undefined) {

--- a/test/client/client_instance.test.js
+++ b/test/client/client_instance.test.js
@@ -1838,6 +1838,27 @@ const encode = object => base64url.encode(JSON.stringify(object));
         });
     });
 
+    it('validates s_hash when returned from token endpoint', function () {
+      const access_token = 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y'; // eslint-disable-line camelcase, max-len
+      const state = 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y'; // eslint-disable-line camelcase, max-len
+      const s_hash = '77QmUPtjPfzWtF2AnpK9RQ'; // eslint-disable-line camelcase
+      const nonce = 'foobar';
+
+      return new this.IdToken(this.keystore.get(), 'RS256', {
+        s_hash,
+        nonce,
+        iss: this.issuer.issuer,
+        sub: 'userId',
+        aud: this.client.client_id,
+        exp: now() + 3600,
+        iat: now(),
+      })
+        .then((token) => {
+          const tokenset = new TokenSet({ access_token, id_token: token });
+          return this.client.validateIdToken(tokenset, nonce, 'token', null, state);
+        });
+    });
+
     it('fails with the wrong at_hash', function () {
       const access_token = 'jHkWEdUXMU1BwAsC4vtUsZwnNvTIxEl0z9K3vx5KF0Y'; // eslint-disable-line camelcase, max-len
       const at_hash = 'notvalid77QmUPtjPfzWtF2AnpK9RQ'; // eslint-disable-line camelcase


### PR DESCRIPTION
This is required in the OpenID Foundation's FAPI profile if s_hash hasn’t
been returned from the authorization endpoint.