### PR TITLE
fix: support setting alternative redirect_uri

### DIFF
--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -88,7 +88,7 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
         params.nonce = random();
       }
 
-      req.session[sessionKey] = _.pick(params, 'nonce', 'state', 'max_age', 'response_type');
+      req.session[sessionKey] = _.pick(params, 'nonce', 'state', 'max_age', 'response_type', 'redirect_uri');
 
       if (this._usePKCE) {
         const verifier = random();
@@ -130,7 +130,7 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
     } catch (err) {}
 
     const opts = _.defaults({}, options, {
-      redirect_uri: this._params.redirect_uri,
+      redirect_uri: session.redirect_uri || this._params.redirect_uri,
     });
 
     const checks = {

--- a/test/passport/passport_strategy.test.js
+++ b/test/passport/passport_strategy.test.js
@@ -71,7 +71,7 @@ const { Issuer, Strategy } = require('../../lib');
         expect(target).to.include('redirect_uri=');
         expect(target).to.include('scope=');
         expect(req.session).to.have.property('oidc:op.example.com');
-        expect(req.session['oidc:op.example.com']).to.have.keys('state', 'response_type');
+        expect(req.session['oidc:op.example.com']).to.have.keys('redirect_uri', 'state', 'response_type');
       });
 
       it('starts authentication requests for POSTs', function () {
@@ -89,7 +89,7 @@ const { Issuer, Strategy } = require('../../lib');
         expect(target).to.include('redirect_uri=');
         expect(target).to.include('scope=');
         expect(req.session).to.have.property('oidc:op.example.com');
-        expect(req.session['oidc:op.example.com']).to.have.keys('state', 'response_type');
+        expect(req.session['oidc:op.example.com']).to.have.keys('redirect_uri', 'state', 'response_type');
       });
 
       it('can have redirect_uri and scope specified', function () {
@@ -110,6 +110,27 @@ const { Issuer, Strategy } = require('../../lib');
         expect(strategy.redirect.calledOnce).to.be.true;
         const target = strategy.redirect.firstCall.args[0];
         expect(target).to.include(`redirect_uri=${encodeURIComponent('https://example.com/cb')}`);
+        expect(target).to.include('scope=openid%20profile');
+      });
+
+      it('can override redirect_uri', function () {
+        const strategy = new Strategy({
+          client: this.client,
+          params: {
+            redirect_uri: 'https://example.com/cb',
+            scope: 'openid profile',
+          },
+        }, () => {});
+
+        const req = new MockRequest('GET', '/login/oidc');
+        req.session = {};
+
+        strategy.redirect = sinon.spy();
+        strategy.authenticate(req, { redirect_uri: 'https://example.com/cb2' });
+
+        expect(strategy.redirect.calledOnce).to.be.true;
+        const target = strategy.redirect.firstCall.args[0];
+        expect(target).to.include(`redirect_uri=${encodeURIComponent('https://example.com/cb2')}`);
         expect(target).to.include('scope=openid%20profile');
       });
 
@@ -135,7 +156,7 @@ const { Issuer, Strategy } = require('../../lib');
         expect(target).to.include('nonce=');
         expect(target).to.include('response_mode=form_post');
         expect(req.session).to.have.property('oidc:op.example.com');
-        expect(req.session['oidc:op.example.com']).to.have.keys('state', 'nonce', 'response_type');
+        expect(req.session['oidc:op.example.com']).to.have.keys('redirect_uri', 'state', 'nonce', 'response_type');
       });
 
       describe('use pkce', () => {
@@ -244,7 +265,7 @@ const { Issuer, Strategy } = require('../../lib');
         strategy.authenticate(req);
 
         expect(req.session).to.have.property('oidc:op.example.com:foo');
-        expect(req.session['oidc:op.example.com:foo']).to.have.keys('state', 'response_type');
+        expect(req.session['oidc:op.example.com:foo']).to.have.keys('redirect_uri', 'state', 'response_type');
       });
     });
 


### PR DESCRIPTION
There was not currently any way to make use of alternate redirect_uri's in the library. This change adds the ability to set `redirect_uri` in the `authenticate()` options.

```javascript
strategy.authenticate(req, { redirect_uri: 'https://example.com/cb2' });
```

This is in-line with the capabilities of oidc.