### PR TITLE
Passport querystring passthrough

### DIFF
--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -32,6 +32,7 @@ function OpenIDConnectStrategy({
   passReqToCallback = false,
   sessionKey,
   usePKCE = false,
+  passThrough = {}
 } = {}, verify) {
   assert(client instanceof Client, 'client must be an instance of openid-client Client');
   assert.equal(typeof verify, 'function', 'verify must be a function');
@@ -45,6 +46,7 @@ function OpenIDConnectStrategy({
   this._usePKCE = usePKCE;
   this._key = sessionKey || `oidc:${url.parse(this._issuer.issuer).hostname}`;
   this._params = params;
+  this._passThrough = passThrough;
 
   if (this._usePKCE === true) {
     const supportedMethods = this._issuer.code_challenge_methods_supported;
@@ -79,8 +81,9 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
 
     /* start authentication request */
     if (_.isEmpty(reqParams)) {
+      const passThroughParams = extractPassthroughParams(this._passThrough, req.query);
       // provide options object with extra authentication parameters
-      const params = _.defaults({}, options, this._params, {
+      const params = _.defaults({}, passThroughParams, options, this._params, {
         state: random(),
       });
 
@@ -107,6 +110,22 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
 
       this.redirect(client.authorizationUrl(params));
       return;
+
+      /** Reads through any supplied pass through keys and copies their values from the querystring */
+      function extractPassthroughParams(passThrough, query) {
+        if (!passThrough) {
+          return {};
+        }
+        return Object.keys(passThrough).reduce(function (result, key) {
+          if (typeof passThrough[key] === 'string') {
+            const queryStringName = query[key]
+            result[key] = query[queryStringName];
+          } else if (passThrough[key]) {
+            result[key] = query[key];
+          }
+          return result;
+        }, {});
+      }
     }
     /* end authentication request */
 


### PR DESCRIPTION
Added a constructor parameter to the passport strategy which allows querystring values to be passed along with the client authorization redirect.