### PR TITLE
Allow pass through of defined querystring parameters in the passport strategy

### DIFF
--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -22,6 +22,22 @@ function verified(err, user, info = {}) {
   }
 }
 
+/** Reads through any supplied pass through keys and copies their values from the querystring */
+function extractPassthroughParams(passThrough, query) {
+  if (!passThrough) {
+    return {};
+  }
+  return Object.keys(passThrough).reduce((result, key) => {
+    if (typeof passThrough[key] === 'string') {
+      const queryStringName = query[key];
+      result[key] = query[queryStringName];
+    } else if (passThrough[key]) {
+      result[key] = query[key];
+    }
+    return result;
+  }, {});
+}
+
 /**
  * @name constructor
  * @api public
@@ -32,7 +48,7 @@ function OpenIDConnectStrategy({
   passReqToCallback = false,
   sessionKey,
   usePKCE = false,
-  passThrough = {}
+  passThrough = {},
 } = {}, verify) {
   assert(client instanceof Client, 'client must be an instance of openid-client Client');
   assert.equal(typeof verify, 'function', 'verify must be a function');
@@ -110,22 +126,6 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
 
       this.redirect(client.authorizationUrl(params));
       return;
-
-      /** Reads through any supplied pass through keys and copies their values from the querystring */
-      function extractPassthroughParams(passThrough, query) {
-        if (!passThrough) {
-          return {};
-        }
-        return Object.keys(passThrough).reduce(function (result, key) {
-          if (typeof passThrough[key] === 'string') {
-            const queryStringName = query[key]
-            result[key] = query[queryStringName];
-          } else if (passThrough[key]) {
-            result[key] = query[key];
-          }
-          return result;
-        }, {});
-      }
     }
     /* end authentication request */
 

--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -48,7 +48,7 @@ function OpenIDConnectStrategy({
   passReqToCallback = false,
   sessionKey,
   usePKCE = false,
-  passThrough = {},
+  passThrough = false,
 } = {}, verify) {
   assert(client instanceof Client, 'client must be an instance of openid-client Client');
   assert.equal(typeof verify, 'function', 'verify must be a function');

--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -29,7 +29,7 @@ function extractPassthroughParams(passThrough, query) {
   }
   return Object.keys(passThrough).reduce((result, key) => {
     if (typeof passThrough[key] === 'string') {
-      const queryStringName = query[key];
+      const queryStringName = passThrough[key];
       result[key] = query[queryStringName];
     } else if (passThrough[key]) {
       result[key] = query[key];
@@ -97,7 +97,7 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
 
     /* start authentication request */
     if (_.isEmpty(reqParams)) {
-      const passThroughParams = extractPassthroughParams(this._passThrough, req.query);
+      const passThroughParams = extractPassthroughParams(this._passThrough, req.query || {});
       // provide options object with extra authentication parameters
       const params = _.defaults({}, passThroughParams, options, this._params, {
         state: random(),

--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -32,6 +32,7 @@ function OpenIDConnectStrategy({
   passReqToCallback = false,
   sessionKey,
   usePKCE = false,
+  passThrough = {}
 } = {}, verify) {
   assert(client instanceof Client, 'client must be an instance of openid-client Client');
   assert.equal(typeof verify, 'function', 'verify must be a function');
@@ -45,6 +46,7 @@ function OpenIDConnectStrategy({
   this._usePKCE = usePKCE;
   this._key = sessionKey || `oidc:${url.parse(this._issuer.issuer).hostname}`;
   this._params = params;
+  this._passThrough = passThrough;
 
   if (this._usePKCE === true) {
     const supportedMethods = this._issuer.code_challenge_methods_supported;
@@ -79,8 +81,9 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
 
     /* start authentication request */
     if (_.isEmpty(reqParams)) {
+      const passThroughParams = extractPassthroughParams(this._passThrough, req.query);
       // provide options object with extra authentication parameters
-      const params = _.defaults({}, options, this._params, {
+      const params = _.defaults({}, passThroughParams, options, this._params, {
         state: random(),
       });
 
@@ -107,6 +110,22 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
 
       this.redirect(client.authorizationUrl(params));
       return;
+
+      /** Reads through any supplied pass through keys and copies their values from the querystring */
+      function extractPassthroughParams(passThrough, query) {
+        if (!passThrough) {
+          return {};
+        }
+        return Object.keys(passThrough).reduce(function (result, key) {
+          if (typeof passThrough[key] === 'string') {
+            const queryStringName = query[key]
+            result[key] = query[queryStringName];
+          } else if (passThrough[key]) {
+            result[key] = query[key];
+          }
+          return result;
+        }, {});
+      }
     }
     /* end authentication request */
 

--- a/test/passport/passport_strategy.test.js
+++ b/test/passport/passport_strategy.test.js
@@ -39,6 +39,34 @@ const { Issuer, Strategy } = require('../../lib');
       });
     });
 
+    it('passes through defined querystring parameters', function () {
+      const strategy = new Strategy({
+        client: this.client,
+        passThrough: {
+          foo: true,
+          test: 'bar',
+        },
+      }, () => {});
+
+      const req = new MockRequest('GET', '/login/oidc?foo=bar&bar=123&baz=456');
+      req.query = {
+        foo: 'bar',
+        bar: '123',
+        baz: '456',
+      };
+      req.session = {};
+
+      strategy.redirect = sinon.spy();
+      strategy.authenticate(req);
+
+      expect(strategy.redirect.calledOnce).to.be.true;
+      const target = strategy.redirect.firstCall.args[0];
+      expect(target).to.include('foo=bar');
+      expect(target).to.include('test=123');
+      expect(target).not.to.include('bar=');
+      expect(target).not.to.include('baz=');
+    });
+
     it('checks for session presence', function (next) {
       const strategy = new Strategy({ client: this.client }, () => {});
 


### PR DESCRIPTION
---
name: Feature addition
type: Feature addition
about: Allow querystring parameters to be passed through when using passport strategy
---

This change allows the definition of querystring parameters that should be passed along to the server during authorization. These parameters will be attached to the redirection URI.