### PR TITLE
feat: support extra claims in JWT client_assertion

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -948,22 +948,26 @@ class Client {
       case 'private_key_jwt':
       case 'client_secret_jwt': {
         const timestamp = now();
-        extraClaims = extraClaims || {};
-        return this.createSign(endpoint).then(sign => sign.update(JSON.stringify(Object.assign({}, {
+        const allClaims = JSON.stringify(Object.assign({}, extraClaims || {}, {
           iat: timestamp,
           exp: timestamp + 60,
           jti: random(),
           iss: this.client_id,
           sub: this.client_id,
           aud: this.issuer[`${endpoint}_endpoint`],
-        }, extraClaims))).final().then((client_assertion) => { // eslint-disable-line camelcase, arrow-body-style
-          return {
-            body: {
-              client_assertion,
-              client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
-            },
-          };
         }));
+
+        return this.createSign(endpoint).then((sign) => { // eslint-disable-line arrow-body-style
+          // eslint-disable-next-line camelcase, arrow-body-style
+          return sign.update(allClaims).final().then((client_assertion) => {
+            return {
+              body: {
+                client_assertion,
+                client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+              },
+            };
+          });
+        });
       }
       default: {
         const encoded = `${formUrlEncode(this.client_id)}:${formUrlEncode(this.client_secret)}`;

--- a/lib/client.js
+++ b/lib/client.js
@@ -410,12 +410,17 @@ class Client {
     }
 
     if (params.code) {
-      const grantCall = () => this.grant({
+      const body = {
         grant_type: 'authorization_code',
         code: params.code,
         redirect_uri: redirectUri,
         code_verifier: checks.code_verifier,
-      })
+      };
+
+      if (params.resource) {
+        body.resource = params.resource;
+      }
+      const grantCall = () => this.grant(body)
         .then(tokenset => this.decryptIdToken(tokenset))
         .then(tokenset => this.validateIdToken(tokenset, checks.nonce, 'token', checks.max_age))
         .then((tokenset) => {

--- a/lib/client.js
+++ b/lib/client.js
@@ -929,7 +929,7 @@ class Client {
    * @name authFor
    * @api private
    */
-  authFor(endpoint = 'token', extraClaims) {
+  authFor(endpoint = 'token', extraClaims = {}) {
     const authMethod = this[`${endpoint}_endpoint_auth_method`];
     switch (authMethod) {
       case 'none':
@@ -948,7 +948,7 @@ class Client {
       case 'private_key_jwt':
       case 'client_secret_jwt': {
         const timestamp = now();
-        const allClaims = JSON.stringify(Object.assign({}, extraClaims || {}, {
+        const allClaims = JSON.stringify(Object.assign({}, extraClaims, {
           iat: timestamp,
           exp: timestamp + 60,
           jti: random(),

--- a/lib/client.js
+++ b/lib/client.js
@@ -785,9 +785,9 @@ class Client {
    * @name grant
    * @api public
    */
-  grant(body) {
+  grant(body, extraClaims) {
     assertIssuerConfiguration(this.issuer, 'token_endpoint');
-    return this.authenticatedPost('token', { body: _.omitBy(body, _.isUndefined) })
+    return this.authenticatedPost('token', { body: _.omitBy(body, _.isUndefined) }, _.omitBy(extraClaims, _.isUndefined))
       .then(expectResponseWithBody(200))
       .then(response => new TokenSet(JSON.parse(response.body)));
   }
@@ -868,8 +868,8 @@ class Client {
    * @name authenticatedPost
    * @api private
    */
-  authenticatedPost(endpoint, httpOptions) {
-    return Promise.resolve(this.authFor(endpoint))
+  authenticatedPost(endpoint, httpOptions, extraClaims) {
+    return Promise.resolve(this.authFor(endpoint, extraClaims))
       .then((auth) => {
         const opts = this.issuer.httpOptions(_.merge(httpOptions, auth, { form: true }));
         return this.httpClient.post(this.issuer[`${endpoint}_endpoint`], opts);
@@ -929,7 +929,7 @@ class Client {
    * @name authFor
    * @api private
    */
-  authFor(endpoint = 'token') {
+  authFor(endpoint = 'token', extraClaims) {
     const authMethod = this[`${endpoint}_endpoint_auth_method`];
     switch (authMethod) {
       case 'none':
@@ -948,14 +948,15 @@ class Client {
       case 'private_key_jwt':
       case 'client_secret_jwt': {
         const timestamp = now();
-        return this.createSign(endpoint).then(sign => sign.update(JSON.stringify({
+        extraClaims = extraClaims || {};
+        return this.createSign(endpoint).then(sign => sign.update(JSON.stringify(Object.assign({}, {
           iat: timestamp,
           exp: timestamp + 60,
           jti: random(),
           iss: this.client_id,
           sub: this.client_id,
           aud: this.issuer[`${endpoint}_endpoint`],
-        })).final().then((client_assertion) => { // eslint-disable-line camelcase, arrow-body-style
+        }, extraClaims))).final().then((client_assertion) => { // eslint-disable-line camelcase, arrow-body-style
           return {
             body: {
               client_assertion,

--- a/lib/helpers/consts.js
+++ b/lib/helpers/consts.js
@@ -37,6 +37,7 @@ const CALLBACK_PROPERTIES = [
   'state',
   'token_type',
   'session_state',
+  'resource',
 ];
 
 const DEFAULT_HTTP_OPTIONS = {


### PR DESCRIPTION
OpenID allows extra claims to be added to client_assertion as part of private_key_jwt and client_secret_jwt. Added an optional and backward compatible way to insert extra claims into the client_assertion during a grant request with unit tests.