### PR TITLE
fix: cache not used as object different each time

### DIFF
--- a/lib/issuer.js
+++ b/lib/issuer.js
@@ -130,8 +130,13 @@ class Issuer {
   key(def, allowMulti) {
     const { cache } = instance(this);
 
+    let cacheKey = def;
+    if (def && def.kid) {
+      cacheKey = def.kid;
+    }
+
     // refresh keystore on every unknown key but also only upto once every minute
-    const freshJwksUri = cache.get(def) || cache.get('throttle');
+    const freshJwksUri = cache.get(cacheKey) || cache.get('throttle');
 
     return this.keystore(!freshJwksUri)
       .then(store => store.all(def))
@@ -139,7 +144,7 @@ class Issuer {
         assert(keys.length, 'no valid key found');
         if (!allowMulti) {
           assert.equal(keys.length, 1, 'multiple matching keys, kid must be provided');
-          cache.set(def, true);
+          cache.set(cacheKey, true);
         }
         return keys[0];
       });

--- a/lib/issuer.js
+++ b/lib/issuer.js
@@ -133,7 +133,12 @@ class Issuer {
 
     let cacheKey = def;
     if (def) {
-      cacheKey = objectHash(def);
+      cacheKey = objectHash(def, {
+        algorithm: 'sha256',
+        ignoreUnknown: true,
+        unorderedArrays: true,
+        unorderedSets: true,
+      });
     }
 
     // refresh keystore on every unknown key but also only upto once every minute

--- a/lib/issuer.js
+++ b/lib/issuer.js
@@ -6,6 +6,7 @@ const jose = require('node-jose');
 const _ = require('lodash');
 const pAny = require('p-any');
 const LRU = require('lru-cache');
+const objectHash = require('object-hash');
 
 const http = require('./helpers/http');
 const httpRequest = require('./helpers/http_request');
@@ -131,8 +132,8 @@ class Issuer {
     const { cache } = instance(this);
 
     let cacheKey = def;
-    if (def && def.kid) {
-      cacheKey = def.kid;
+    if (def) {
+      cacheKey = objectHash(def);
     }
 
     // refresh keystore on every unknown key but also only upto once every minute

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "lodash": "^4.17.11",
     "lru-cache": "^4.1.3",
     "node-jose": "^1.1.0",
+    "object-hash": "^1.3.1",
     "oidc-token-hash": "^3.0.1",
     "p-any": "^1.1.0"
   },


### PR DESCRIPTION
The library used for the cache supports using objects as keys, but checks for pointer equality and not deep or JSON equality ([lru-cache](https://www.npmjs.com/package/lru-cache)).

Since the `key` that we want to cache originate from a `JSON.parse` call ([client.js#L642](https://github.com/panva/node-openid-client/blob/master/lib/client.js#L642), [client.js#L557](https://github.com/panva/node-openid-client/blob/master/lib/client.js#L557)), it is different each time.

Thus, the cache only works for 60 sec for a particular key (thanks to the `throttle` key).