### PR TITLE
fix: increase http timeout to 10s

### DIFF
--- a/lib/helpers/consts.js
+++ b/lib/helpers/consts.js
@@ -44,7 +44,7 @@ const DEFAULT_HTTP_OPTIONS = {
   followRedirect: false,
   headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
   retries: 0,
-  timeout: 1500,
+  timeout: 10000,
 };
 
 const JWT_CONTENT = /^application\/jwt/;

--- a/test/issuer/default_http_options.test.js
+++ b/test/issuer/default_http_options.test.js
@@ -17,7 +17,7 @@ describe('Issuer#defaultHttpOptions', function () {
   });
 
   it('has a rather graceous timeout', function () {
-    expect(Issuer.defaultHttpOptions).to.have.property('timeout', 1500);
+    expect(Issuer.defaultHttpOptions).to.have.property('timeout', 10000);
   });
 });
 


### PR DESCRIPTION
Hi @panva,

Thank you for your quick reactions and fix yesterday!

So as I told you, I was making the PR because of a server that randomly timedout when calling it's key route. So here is the PR that we will use in prod to make 100% sure that this scenario is not happening. Since we have a working cache now it should almost never be used, but better safe than sorry. 