### PR TITLE
docs: fix HTTP debugging example

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -579,7 +579,7 @@ custom.setHttpOptionsDefaults({
   hooks: {
     beforeRequest: [
       (options) => {
-        console.log('--> %s %s', options.method.toUpperCase(), options.href);
+        console.log('--> %s %s', options.method.toUpperCase(), options.url.href);
         console.log('--> HEADERS %o', options.headers);
         if (options.body) {
           console.log('--> BODY %s', options.body);
@@ -588,7 +588,7 @@ custom.setHttpOptionsDefaults({
     ],
     afterResponse: [
       (response) => {
-        console.log('<-- %i FROM %s %s', response.statusCode, response.request.gotOptions.method.toUpperCase(), response.request.gotOptions.href);
+        console.log('<-- %i FROM %s %s', response.statusCode, response.request.options.method.toUpperCase(), response.request.options.url.href);
         console.log('<-- HEADERS %o', response.headers);
         if (response.body) {
           console.log('<-- BODY %s', response.body);


### PR DESCRIPTION
The parameter structure has changed due to the got major version upgrade
which was not yet reflected in the documented example.