### PR TITLE
Replace leftover deprecated "verb" with "method"

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -342,7 +342,7 @@ will also be checked to match the on in the TokenSet's ID Token.
 - `accessToken`: `<string>` &vert; `<TokenSet>` Access Token value. When TokenSet instance is
   provided its `access_token` property will be used automatically.
 - `options`: `<Object>`
-  - `verb`: `<string>` The HTTP verb to use for the request 'GET' or 'POST'. **Default:** 'GET'
+  - `method`: `<string>` The HTTP method to use for the request 'GET' or 'POST'. **Default:** 'GET'
   - `via`: `<string>` The mechanism to use to attach the Access Token to the request. Valid values
     are `header`, `body`, or `query`. **Default:** 'header'.
   - `tokenType`: `<string>` The token type as the Authorization Header scheme. **Default:** 'Bearer'
@@ -366,7 +366,7 @@ Fetches an arbitrary resource with the provided Access Token in an Authorization
 - `options`: `<Object>`
   - `headers`: `<Object>` HTTP Headers to include in the request.
   - `body`: `<string>` &vert; `<Buffer>` HTTP Body to include in the request.
-  - `method`: `<string>` The HTTP verb to use for the request. **Default:** 'GET'
+  - `method`: `<string>` The HTTP method to use for the request. **Default:** 'GET'
   - `tokenType`: `<string>` The token type as the Authorization Header scheme. **Default:** 'Bearer'
     or the `token_type` property from a passed in TokenSet.
   - `DPoP`: `KeyObject` &vert; `<Object>` When provided the client will send a DPoP Proof JWT to the 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1057,7 +1057,7 @@ module.exports = (issuer, aadIssValidation = false) => class Client extends Base
     };
 
     if (options.method !== 'GET' && options.method !== 'POST') {
-      throw new TypeError('#userinfo() verb can only be POST or a GET');
+      throw new TypeError('#userinfo() method can only be POST or a GET');
     }
 
     if (via === 'query' && options.method !== 'GET') {

--- a/test/client/client_instance.test.js
+++ b/test/client/client_instance.test.js
@@ -1062,7 +1062,7 @@ describe('Client', () => {
 
       return client.userinfo('tokenValue', { method: 'PUT' }).then(fail, (error) => {
         expect(error).to.be.instanceof(TypeError);
-        expect(error.message).to.eql('#userinfo() verb can only be POST or a GET');
+        expect(error.message).to.eql('#userinfo() method can only be POST or a GET');
       });
     });
 


### PR DESCRIPTION
This PR has only 1 true fix: in the doc of https://github.com/panva/node-openid-client/blob/master/docs/README.md#clientuserinfoaccesstoken-options

The other substitutions have been done for consistency. The substitution in the error message is debatable, but code should not rely on error messages, error messages are not an API. I can delete this change if you want though 🙂