### PR TITLE
Update Auth0 sponsorship link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ conforms to the following profiles of the OpenID Connect™ protocol
 
 ## Sponsor
 
-[<img width="65" height="65" align="left" src="https://avatars.githubusercontent.com/u/2824157?s=75&v=4" alt="auth0-logo">][sponsor-auth0] If you want to quickly add OpenID Connect authentication to Node.js apps, feel free to check out Auth0's Node.js SDK and free plan at [auth0.com/overview][sponsor-auth0].<br><br>
+[<img width="65" height="65" align="left" src="https://avatars.githubusercontent.com/u/2824157?s=75&v=4" alt="auth0-logo">][sponsor-auth0] If you want to quickly add OpenID Connect authentication to Node.js apps, feel free to check out Auth0's Node.js SDK and free plan at [auth0.com/developers?utm_source=GHsponsor&utm_medium=GHsponsor&utm_campaign=node-openid-client&utm_content=auth][sponsor-auth0].<br><br>
 
 ## Support
 


### PR DESCRIPTION
Hey

We recently launched a new page specifically geared towards developers on auth0.com.
Can we change the link in the sponsorship message?

Thanks again for your open-source work!

Sam