### PR TITLE
feat: add callback extras to strategy options

### DIFF
--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -30,6 +30,7 @@ function OpenIDConnectStrategy({
   passReqToCallback = false,
   sessionKey,
   usePKCE,
+  extras = {},
 } = {}, verify) {
   if (!(client instanceof BaseClient)) {
     throw new TypeError('client must be an instance of openid-client Client');
@@ -50,6 +51,7 @@ function OpenIDConnectStrategy({
   this._usePKCE = usePKCE;
   this._key = sessionKey || `oidc:${url.parse(this._issuer.issuer).hostname}`;
   this._params = cloneDeep(params);
+  this._extras = cloneDeep(extras);
 
   if (!this._params.response_type) this._params.response_type = resolveResponseType.call(client);
   if (!this._params.redirect_uri) this._params.redirect_uri = resolveRedirectUri.call(client);
@@ -147,7 +149,7 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
       response_type: responseType,
     };
 
-    const tokenset = await client.callback(opts.redirect_uri, reqParams, checks);
+    const tokenset = await client.callback(opts.redirect_uri, reqParams, checks, this._extras);
 
     const passReq = this._passReqToCallback;
     const loadUserinfo = this._verify.length > (passReq ? 3 : 2) && client.issuer.userinfo_endpoint;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -675,6 +675,11 @@ export interface StrategyOptions<TClient extends Client> {
    * Authorization Request parameters. The strategy will use these.
    */
   params?: AuthorizationParameters;
+
+  /**
+   * "extras" argument value passed to the client.callback() call.
+   */
+  extras?: CallbackExtras;
   /**
    * Boolean specifying whether the verify function should get the request object as first argument instead.
    * Default: 'false'


### PR DESCRIPTION
### The problem
Currently the Strategy does not support client assertions making it troublesome to use with Passport.

### Proposed solution
Pass option `extras: CallbackExtras` to the `StrategyOptions` interface like so:

```
const strategy = new Strategy({
        client,
        params: {
            scope: 'openid profile',
        },
        extras: {
            clientAssertionPayload: {
                aud: metadata.issuer
            }
        }
    }, (tokenSet: TokenSet, done: (_err: any, _user?: any) => void) => {
        done(null, tokenSet)
    });
```

The function `OpenIDConnectStrategy.prototype.authenticate` is changed to include the `client._extras` as the last parameter to `client.callback`