### PR TITLE
feat(typescript): add userinfo response generics

### DIFF
--- a/types/openid-client-tests.ts
+++ b/types/openid-client-tests.ts
@@ -113,6 +113,21 @@ async (req: IncomingMessage) => {
 
     //
 
+    const userinfoGeneric = await client.userinfo<{ someProp: number }>(callbackResponse);
+    console.log(userinfoGeneric.someProp);
+
+    //
+
+    const userinfoAddressGeneric = await client.userinfo<{ someProp: number }, { street: string }>(callbackResponse);
+    console.log(userinfoAddressGeneric.address ? userinfoAddressGeneric.address.street : undefined);
+
+    //
+
+    const userinfoOverride = await client.userinfo<{ email_verified: string }>(callbackResponse);
+    console.log(userinfoOverride.email_verified);
+
+    //
+
     await client.requestResource('https://rs.example.com/resource', 'access token', { headers: { Accept: 'application/json' } });
     const resource = await client.requestResource('https://rs.example.com/resource', callbackResponse, { headers: { Accept: 'application/json' } });
     console.log(resource.body.byteLength);

--- a/types/openid-client-tests.ts
+++ b/types/openid-client-tests.ts
@@ -119,12 +119,12 @@ async (req: IncomingMessage) => {
     //
 
     const userinfoAddressGeneric = await client.userinfo<{ someProp: number }, { street: string }>(callbackResponse);
-    console.log(userinfoAddressGeneric.address ? userinfoAddressGeneric.address.street : undefined);
+    console.log(userinfoAddressGeneric.address ? userinfoAddressGeneric.address.street.substring(0) : undefined);
 
     //
 
     const userinfoOverride = await client.userinfo<{ email_verified: string }>(callbackResponse);
-    console.log(userinfoOverride.email_verified);
+    console.log(userinfoOverride.email_verified.substring(0));
 
     //
 


### PR DESCRIPTION
By using generics, we can enforce proper type checking without the need of casting. This is just the first, because `[key: string]: unknown` is used some more in the type declarations.