### PR TITLE
fix(passport-strategy): ensure session is saved before redirecting

### DIFF
--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -116,6 +116,13 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
         }
       }
 
+      await new Promise((resolve, reject) => {
+        req.session.save((err) => {
+          if (err) reject(err);
+          resolve();
+        });
+      });
+
       this.redirect(client.authorizationUrl(params));
       return;
     }

--- a/test/passport/passport_strategy.test.js
+++ b/test/passport/passport_strategy.test.js
@@ -104,17 +104,19 @@ describe('OpenIDConnectStrategy', () => {
   });
 
   describe('initate', function () {
-    it('starts authentication requests for GETs', function () {
+    it('starts authentication requests for GETs', async function () {
       const params = { foo: 'bar' };
       const strategy = new Strategy({ client: this.client, params }, () => {});
 
       const req = new MockRequest('GET', '/login/oidc');
-      req.session = {};
+      req.session = { save: sinon.stub().callsFake((fn) => fn()) };
 
       strategy.redirect = sinon.spy();
-      strategy.authenticate(req);
+
+      await strategy.authenticate(req);
 
       expect(params).to.eql({ foo: 'bar' });
+      expect(req.session.save.calledOnce).to.be.true;
       expect(strategy.redirect.calledOnce).to.be.true;
       const target = strategy.redirect.firstCall.args[0];
       expect(target).to.include('redirect_uri=');
@@ -123,16 +125,17 @@ describe('OpenIDConnectStrategy', () => {
       expect(req.session['oidc:op.example.com']).to.have.keys('state', 'response_type', 'code_verifier');
     });
 
-    it('starts authentication requests for POSTs', function () {
+    it('starts authentication requests for POSTs', async function () {
       const strategy = new Strategy({ client: this.client }, () => {});
 
       const req = new MockRequest('POST', '/login/oidc');
-      req.session = {};
+      req.session = { save: sinon.stub().callsFake((fn) => fn()) };
       req.body = {};
 
       strategy.redirect = sinon.spy();
-      strategy.authenticate(req);
+      await strategy.authenticate(req);
 
+      expect(req.session.save.calledOnce).to.be.true;
       expect(strategy.redirect.calledOnce).to.be.true;
       const target = strategy.redirect.firstCall.args[0];
       expect(target).to.include('redirect_uri=');
@@ -141,7 +144,7 @@ describe('OpenIDConnectStrategy', () => {
       expect(req.session['oidc:op.example.com']).to.have.keys('state', 'response_type', 'code_verifier');
     });
 
-    it('can have redirect_uri and scope specified', function () {
+    it('can have redirect_uri and scope specified', async function () {
       const strategy = new Strategy({
         client: this.client,
         params: {
@@ -151,18 +154,19 @@ describe('OpenIDConnectStrategy', () => {
       }, () => {});
 
       const req = new MockRequest('GET', '/login/oidc');
-      req.session = {};
+      req.session = { save: sinon.stub().callsFake((fn) => fn()) };
 
       strategy.redirect = sinon.spy();
-      strategy.authenticate(req);
+      await strategy.authenticate(req);
 
+      expect(req.session.save.calledOnce).to.be.true;
       expect(strategy.redirect.calledOnce).to.be.true;
       const target = strategy.redirect.firstCall.args[0];
       expect(target).to.include(`redirect_uri=${encodeURIComponent('https://example.com/cb')}`);
       expect(target).to.include('scope=openid%20profile');
     });
 
-    it('can have authorization parameters specified at runtime', function () {
+    it('can have authorization parameters specified at runtime', async function () {
       const strategy = new Strategy({
         client: this.client,
         params: {
@@ -172,17 +176,18 @@ describe('OpenIDConnectStrategy', () => {
       }, () => {});
 
       const req = new MockRequest('GET', '/login/oidc');
-      req.session = {};
+      req.session = { save: sinon.stub().callsFake((fn) => fn()) };
 
       strategy.redirect = sinon.spy();
-      strategy.authenticate(req, { resource: 'urn:example:foo' });
+      await strategy.authenticate(req, { resource: 'urn:example:foo' });
 
+      expect(req.session.save.calledOnce).to.be.true;
       expect(strategy.redirect.calledOnce).to.be.true;
       const target = strategy.redirect.firstCall.args[0];
       expect(target).to.include(`resource=${encodeURIComponent('urn:example:foo')}`);
     });
 
-    it('automatically includes nonce for where it applies', function () {
+    it('automatically includes nonce for where it applies', async function () {
       const strategy = new Strategy({
         client: this.client,
         params: {
@@ -192,11 +197,12 @@ describe('OpenIDConnectStrategy', () => {
       }, () => {});
 
       const req = new MockRequest('GET', '/login/oidc');
-      req.session = {};
+      req.session = { save: sinon.stub().callsFake((fn) => fn()) };
 
       strategy.redirect = sinon.spy();
-      strategy.authenticate(req);
+      await strategy.authenticate(req);
 
+      expect(req.session.save.calledOnce).to.be.true;
       expect(strategy.redirect.calledOnce).to.be.true;
       const target = strategy.redirect.firstCall.args[0];
       expect(target).to.include('redirect_uri=');
@@ -258,18 +264,19 @@ describe('OpenIDConnectStrategy', () => {
         }).to.throw('foobar is not valid/implemented PKCE code_challenge_method');
       });
 
-      it('can be set to use PKCE (S256)', function () {
+      it('can be set to use PKCE (S256)', async function () {
         const strategy = new Strategy({
           client: this.client,
           usePKCE: 'S256',
         }, () => {});
 
         const req = new MockRequest('GET', '/login/oidc');
-        req.session = {};
+        req.session = { save: sinon.stub().callsFake((fn) => fn()) };
 
         strategy.redirect = sinon.spy();
-        strategy.authenticate(req);
+        await strategy.authenticate(req);
 
+        expect(req.session.save.calledOnce).to.be.true;
         expect(strategy.redirect.calledOnce).to.be.true;
         const target = strategy.redirect.firstCall.args[0];
         expect(target).to.include('code_challenge_method=S256');
@@ -278,18 +285,19 @@ describe('OpenIDConnectStrategy', () => {
         expect(req.session['oidc:op.example.com']).to.have.property('code_verifier');
       });
 
-      it('can be set to use PKCE (plain)', function () {
+      it('can be set to use PKCE (plain)', async function () {
         const strategy = new Strategy({
           client: this.client,
           usePKCE: 'plain',
         }, () => {});
 
         const req = new MockRequest('GET', '/login/oidc');
-        req.session = {};
+        req.session = { save: sinon.stub().callsFake((fn) => fn()) };
 
         strategy.redirect = sinon.spy();
-        strategy.authenticate(req);
+        await strategy.authenticate(req);
 
+        expect(req.session.save.calledOnce).to.be.true;
         expect(strategy.redirect.calledOnce).to.be.true;
         const target = strategy.redirect.firstCall.args[0];
         expect(target).not.to.include('code_challenge_method');


### PR DESCRIPTION
Some session stores could be a little bit slow sometimes, specially the aaS ones during the initial request. 

Also looks like it's the [right](https://github.com/expressjs/session#sessionsavecallback) way to handle sessions while doing redirects.

Probably will solve issues like: #237 #281 