### PR TITLE
Allow HEAD in callbackParams

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -338,6 +338,7 @@ module.exports = (issuer, aadIssValidation = false) => class Client extends Base
     if (isIncomingMessage) {
       switch (input.method) {
         case 'GET':
+        case 'HEAD':
           return pickCb(url.parse(input.url, true).query);
         case 'POST':
           if (input.body === undefined) {


### PR DESCRIPTION
http `HEAD` should perform the same actions as `GET`, but not return a body. This fix will return the same headers.

Chrome (especially on Windows) is seen hitting our server logs against `HEAD /login` and this is causing an "invalid IncomingMessage method" error. This PR fixes the problem.