### PR TITLE
feat: add abort control over Device Flow Handle polling

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -793,7 +793,8 @@ first place.
 
 <!-- TOC DeviceFlowHandle START -->
 - [Class: &lt;DeviceFlowHandle&gt;](#class-deviceflowhandle)
-  - [handle.poll()](#handlepoll)
+  - [handle.poll([options])](#handlepolloptions)
+  - [handle.abort()](#handleabort)
   - [handle.user_code](#handleuser_code)
   - [handle.verification_uri](#handleverification_uri)
   - [handle.verification_uri_complete](#handleverification_uri_complete)
@@ -812,13 +813,22 @@ other defined response properties. A handle is instantiated by calling
 
 ---
 
-#### `handle.poll()`
+#### `handle.poll([options])`
 
 This will continuously poll the token_endpoint and resolve with a TokenSet once one is received.
 This will handle the defined `authorization_pending` and `slow_down` "soft" errors and continue
 polling but upon any other error it will reject.
 
+- `options`: `<Object>`
+  - `signal`: `<AbortSignal>` An optional AbortSignal that can be used to abort polling. When
+  if the signal is aborted the next interval in the poll will make the returned promise reject.
 - Returns: `Promise<TokenSet>`
+
+---
+
+#### `handle.abort()`
+
+This will abort ongoing polling. The next interval in the poll will result in a rejection.
 
 ---
 

--- a/lib/device_flow_handle.js
+++ b/lib/device_flow_handle.js
@@ -32,7 +32,15 @@ class DeviceFlowHandle {
     instance(this).interval = response.interval * 1000 || 5000;
   }
 
-  async poll() {
+  abort() {
+    instance(this).aborted = true;
+  }
+
+  async poll({ signal } = {}) {
+    if ((signal && signal.aborted) || instance(this).aborted) {
+      throw new RPError('polling aborted');
+    }
+
     if (this.expired()) {
       throw new RPError('the device code %j has expired and the device authorization session has concluded', this.device_code);
     }
@@ -61,7 +69,7 @@ class DeviceFlowHandle {
         case 'slow_down':
           instance(this).interval += 5000;
         case 'authorization_pending': // eslint-disable-line no-fallthrough
-          return this.poll();
+          return this.poll({ signal });
         default:
           throw err;
       }


### PR DESCRIPTION
Example using AbortController.

```js
const ac = new AbortController()

setTimeout(() => ac.abort(), 10000)

try {
  await handle.poll({ signal: ac.signal })
} catch (err) {
  console.log(err)
}
```

Example using handle.abort().

```js
setTimeout(() => handle.abort(), 10000)

try {
  await handle.poll({ signal: ac.signal })
} catch (err) {
  console.log(err)
}
```

resolves #355
closes #356