### PR TITLE
Make static Issuer methods generic

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -676,13 +676,13 @@ export class Issuer<TClient extends Client> {
    * performs both openid-configuration and oauth-authorization-server requests.
    * @param issuer Issuer Identifier or metadata URL
    */
-  static discover(issuer: string): Promise<Issuer<Client>>;
+  static discover<TClient>(issuer: string): Promise<Issuer<TClient>>;
 
   /**
    * Performs OpenID Provider Issuer Discovery based on End-User input.
    * @param input EMAIL, URL, Hostname and Port, acct or syntax input
    */
-  static webfinger(input: string): Promise<Issuer<Client>>;
+  static webfinger<TClient>(input: string): Promise<Issuer<TClient>>;
 
   static [custom.http_options]: CustomHttpOptionsProvider;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -676,13 +676,13 @@ export class Issuer<TClient extends Client> {
    * performs both openid-configuration and oauth-authorization-server requests.
    * @param issuer Issuer Identifier or metadata URL
    */
-  static discover<TClient>(issuer: string): Promise<Issuer<TClient>>;
+  static discover<TClient extends Client>(issuer: string): Promise<Issuer<TClient>>;
 
   /**
    * Performs OpenID Provider Issuer Discovery based on End-User input.
    * @param input EMAIL, URL, Hostname and Port, acct or syntax input
    */
-  static webfinger<TClient>(input: string): Promise<Issuer<TClient>>;
+  static webfinger<TClient extends Client>(input: string): Promise<Issuer<TClient>>;
 
   static [custom.http_options]: CustomHttpOptionsProvider;
 


### PR DESCRIPTION
Allows the client returned from either `Issuer<TClient>.discover` or `Issuer<TClient>.webfinger` to be generically typed.