### PR TITLE
fix(security): ensure got is `>= 11.8.2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "aggregate-error": "^3.1.0",
-    "got": "^11.8.0",
+    "got": "^11.8.2",
     "jose": "^2.0.5",
     "lru-cache": "^6.0.0",
     "make-error": "^1.3.6",


### PR DESCRIPTION
got 11.8.2 updates `cacheable-request` to `7.0.2` 
that updates to fixed `normalize-url` 😅