### PR TITLE
Fix #397 - Add remaining properties from RFC7662 to IntrospectionResponse typedef

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -380,6 +380,8 @@ export interface IntrospectionResponse {
   username?: string;
   aud?: string | string[];
   scope: string;
+  sub?: string;
+  nbf?: number;
   token_type?: string;
   cnf?: {
     "x5t#S256"?: string;


### PR DESCRIPTION
Adding `sub` and `nbf` to IntrospectionResponse type to match RFC7662 top-level members.

`scope` really should be optional here, but that would be a breaking change so leaving as-is.


