### PR TITLE
Populate 'ath' claim in DPoP when access token is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ openid-client.
   - RP-Initiated Logout
 - [Financial-grade API - Part 2: Read and Write API Security Profile (FAPI) - ID2][feature-fapi]
 - [JWT Secured Authorization Response Mode for OAuth 2.0 (JARM) - ID1][feature-jarm]
-- [OAuth 2.0 Demonstration of Proof-of-Possession at the Application Layer (DPoP) - draft 01][feature-dpop]
+- [OAuth 2.0 Demonstration of Proof-of-Possession at the Application Layer (DPoP) - draft 03][feature-dpop]
 
 Updates to draft specifications (DPoP, JARM, and FAPI) are released as MINOR library versions,
 if you utilize these specification implementations consider using the tilde `~` operator in your
@@ -297,7 +297,7 @@ See [Customizing (docs)](https://github.com/panva/node-openid-client/blob/master
 [feature-rp-logout]: https://openid.net/specs/openid-connect-session-1_0.html#RPLogout
 [feature-jarm]: https://openid.net/specs/openid-financial-api-jarm-ID1.html
 [feature-fapi]: https://openid.net/specs/openid-financial-api-part-2-ID2.html
-[feature-dpop]: https://tools.ietf.org/html/draft-ietf-oauth-dpop-01
+[feature-dpop]: https://tools.ietf.org/html/draft-ietf-oauth-dpop-03
 [feature-par]: https://www.rfc-editor.org/rfc/rfc9126.html
 [feature-jar]: https://www.rfc-editor.org/rfc/rfc9101.html
 [openid-certified-link]: https://openid.net/certification/

--- a/lib/client.js
+++ b/lib/client.js
@@ -20,7 +20,7 @@ const processResponse = require('./helpers/process_response');
 const TokenSet = require('./token_set');
 const { OPError, RPError } = require('./errors');
 const now = require('./helpers/unix_timestamp');
-const { random, sha256 } = require('./helpers/generators');
+const { random } = require('./helpers/generators');
 const request = require('./helpers/request');
 const {
   CALLBACK_PROPERTIES, CLIENT_DEFAULTS, JWT_CONTENT, CLOCK_TOLERANCE,
@@ -1013,8 +1013,9 @@ module.exports = (issuer, aadIssValidation = false) => class Client extends Base
       method,
       headers,
       body,
-      tokenType = accessToken instanceof TokenSet ? accessToken.token_type : 'Bearer',
       DPoP,
+      // eslint-disable-next-line no-nested-ternary
+      tokenType = DPoP ? 'DPoP' : accessToken instanceof TokenSet ? accessToken.token_type : 'Bearer',
     } = {},
   ) {
     if (accessToken instanceof TokenSet) {
@@ -1685,7 +1686,7 @@ function dpopProof(payload, jwk, accessToken) {
 
   let ath;
   if (accessToken) {
-    ath = sha256(accessToken);
+    ath = base64url.encode(crypto.createHash('sha256').update(accessToken).digest());
   }
 
   return jose.JWS.sign({
@@ -1705,7 +1706,7 @@ Object.defineProperty(BaseClient.prototype, 'dpopProof', {
   configurable: true,
   value(...args) {
     process.emitWarning(
-      'The DPoP APIs implements an IETF draft. Breaking draft implementations are included as minor versions of the openid-client library, therefore, the ~ semver operator should be used and close attention be payed to library changelog as well as the drafts themselves.',
+      'The DPoP APIs implements an IETF draft (https://www.ietf.org/archive/id/draft-ietf-oauth-dpop-03.html). Breaking draft implementations are included as minor versions of the openid-client library, therefore, the ~ semver operator should be used and close attention be payed to library changelog as well as the drafts themselves.',
       'DraftWarning',
     );
     Object.defineProperty(BaseClient.prototype, 'dpopProof', {

--- a/lib/client.js
+++ b/lib/client.js
@@ -20,7 +20,7 @@ const processResponse = require('./helpers/process_response');
 const TokenSet = require('./token_set');
 const { OPError, RPError } = require('./errors');
 const now = require('./helpers/unix_timestamp');
-const { random } = require('./helpers/generators');
+const { random, sha256 } = require('./helpers/generators');
 const request = require('./helpers/request');
 const {
   CALLBACK_PROPERTIES, CLIENT_DEFAULTS, JWT_CONTENT, CLOCK_TOLERANCE,
@@ -1039,7 +1039,7 @@ module.exports = (issuer, aadIssValidation = false) => class Client extends Base
       responseType: 'buffer',
       method,
       url: resourceUrl,
-    }, { mTLS, DPoP });
+    }, { accessToken, mTLS, DPoP });
   }
 
   /**
@@ -1659,7 +1659,7 @@ Object.defineProperty(BaseClient.prototype, 'validateJARM', {
  * @name dpopProof
  * @api private
  */
-function dpopProof(payload, jwk) {
+function dpopProof(payload, jwk, accessToken) {
   if (!isPlainObject(payload)) {
     throw new TypeError('payload must be a plain object');
   }
@@ -1683,9 +1683,15 @@ function dpopProof(payload, jwk) {
     [alg] = key.algorithms('sign');
   }
 
+  let ath;
+  if (accessToken) {
+    ath = sha256(accessToken);
+  }
+
   return jose.JWS.sign({
     iat: now(),
     jti: random(),
+    ath,
     ...payload,
   }, jwk, {
     alg,

--- a/lib/helpers/generators.js
+++ b/lib/helpers/generators.js
@@ -3,13 +3,11 @@ const { createHash, randomBytes } = require('crypto');
 const base64url = require('./base64url');
 
 const random = (bytes = 32) => base64url.encode(randomBytes(bytes));
-const sha256 = (input) => base64url.encode(createHash('sha256').update(input).digest());
 
 module.exports = {
   random,
   state: random,
   nonce: random,
   codeVerifier: random,
-  sha256,
-  codeChallenge: sha256,
+  codeChallenge: (codeVerifier) => base64url.encode(createHash('sha256').update(codeVerifier).digest()),
 };

--- a/lib/helpers/generators.js
+++ b/lib/helpers/generators.js
@@ -3,11 +3,13 @@ const { createHash, randomBytes } = require('crypto');
 const base64url = require('./base64url');
 
 const random = (bytes = 32) => base64url.encode(randomBytes(bytes));
+const sha256 = (input) => base64url.encode(createHash('sha256').update(input).digest());
 
 module.exports = {
   random,
   state: random,
   nonce: random,
   codeVerifier: random,
-  codeChallenge: (codeVerifier) => base64url.encode(createHash('sha256').update(codeVerifier).digest()),
+  sha256,
+  codeChallenge: sha256,
 };

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -22,7 +22,7 @@ setDefaults({
   throwHttpErrors: false,
 });
 
-module.exports = async function request(options, { mTLS = false, DPoP } = {}) {
+module.exports = async function request(options, { accessToken, mTLS = false, DPoP } = {}) {
   const { url } = options;
   isAbsoluteUrl(url);
   const optsFn = this[HTTP_OPTIONS];
@@ -33,7 +33,7 @@ module.exports = async function request(options, { mTLS = false, DPoP } = {}) {
     opts.headers.DPoP = this.dpopProof({
       htu: url,
       htm: options.method,
-    }, DPoP);
+    }, DPoP, accessToken);
   }
 
   if (optsFn) {


### PR DESCRIPTION
Fixes #406 

According to draft-03 of DPoP:

```
   When the DPoP proof is used in conjunction with the presentation of
   an access token, see Section 7, the DPoP proof also contains the
   following claim:

   *  "ath": hash of the access token (REQUIRED).  The value MUST be the
      result of a base64url encoding (with no padding) the SHA-256 hash
      of the ASCII encoding of the associated access token's value.
```

The DPoP implementation in this repository currently does not provide the `ath` claim when used with an access token (e.g., in `userinfo()` and `requestResource()`).  This PR updates the DPoP proof construction code so that if an access token is provided, then the `ath` parameter is included in the proof.