### PR TITLE
Update HTTP debug to include FORM data

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -616,6 +616,9 @@ custom.setHttpOptionsDefaults({
         if (options.body) {
           console.log('--> BODY %s', options.body);
         }
+        if (options.form) {
+          console.log('--> FORM %s', options.form);
+        }
       },
     ],
     afterResponse: [


### PR DESCRIPTION
Some operations utilise a form post which does not show up in debug via `options.body`. This PR displays `options.form` to capture this.