### PR TITLE
Set engineStrict false in order to enable Yarn to install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openid-client",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "OpenID Connect Relying Party (RP, Client) implementation for Node.js runtime, supports passportjs",
   "keywords": [
     "auth",
@@ -70,6 +70,7 @@
     "sinon": "^9.2.0",
     "timekeeper": "^2.2.0"
   },
+  "engineStrict": false,
   "engines": {
     "node": "^12.19.0 || ^14.15.0 || ^16.13.0"
   },


### PR DESCRIPTION
Set engineStrict to false in order to enable Yarn to install when an odd-numbered version of Node is in use.

Signed-off-by: Lucas Gonze <lucas@gonze.com>