### PR TITLE
#466 adding application/jwk-set+json for JWTS calls

### DIFF
--- a/lib/helpers/issuer.js
+++ b/lib/helpers/issuer.js
@@ -38,7 +38,7 @@ async function getKeyStore(reload = false) {
             responseType: 'json',
             url: this.jwks_uri,
             headers: {
-              Accept: 'application/json',
+              Accept: 'application/json, application/jwk-set+json',
             },
           })
           .finally(() => {

--- a/test/client/client_instance.test.js
+++ b/test/client/client_instance.test.js
@@ -2513,7 +2513,7 @@ describe('Client', () => {
 
     before(function () {
       nock('https://op.example.com')
-        .matchHeader('Accept', 'application/json')
+        .matchHeader('Accept', 'application/json, application/jwk-set+json')
         .persist()
         .get('/certs')
         .reply(200, this.keystore.toJWKS());
@@ -3802,7 +3802,7 @@ describe('Client', () => {
 
     before(function () {
       nock('https://op.example.com')
-        .matchHeader('Accept', 'application/json')
+        .matchHeader('Accept', 'application/json, application/jwk-set+json')
         .get('/certs')
         .reply(200, this.keystore.toJWKS());
 
@@ -4108,7 +4108,7 @@ describe('Client', () => {
 
     before(function () {
       nock('https://op.example.com')
-        .matchHeader('Accept', 'application/json')
+        .matchHeader('Accept', 'application/json, application/jwk-set+json')
         .get('/certs')
         .reply(200, this.keystore.toJWKS());
 

--- a/test/issuer/issuer_instance.test.js
+++ b/test/issuer/issuer_instance.test.js
@@ -35,7 +35,7 @@ describe('Issuer', () => {
 
     before(function () {
       nock('https://op.example.com')
-        .matchHeader('Accept', 'application/json')
+        .matchHeader('Accept', 'application/json, application/jwk-set+json')
         .get('/certs')
         .reply(200, this.keystore.toJWKS());
 


### PR DESCRIPTION
Adding application/jwk-set+json as an accepted header, since some OIDC providers are stricter and will return a 406 error code otherwise.