### PR TITLE
fix: client id type

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -174,7 +174,7 @@ class BaseClient {
     this.#issuer = issuer;
     this.#aadIssValidation = aadIssValidation;
 
-    if (typeof metadata.client_id !== 'string' || !metadata.client_id) {
+    if ((typeof metadata.client_id !== 'string' && typeof metadata.client_id !== 'number') || !metadata.client_id) {
       throw new TypeError('client_id is required');
     }
 


### PR DESCRIPTION
I found a bug AUTH_DISCORD_CLIENT_ID="replace with raw of number" return error, if i insert an alphabet between the number it works...this is due to discord client id is all pure number...

<img width="142" alt="image" src="https://user-images.githubusercontent.com/77238199/156875132-434381aa-5ef9-46f6-8abe-449060db0431.png">

We should accept string && number as type for client_id as discord using pure numbers

<img width="862" alt="image" src="https://user-images.githubusercontent.com/77238199/156875087-d4d5bddb-e359-4a2a-aa57-be9d56c4d6e2.png">

Reference: https://github.com/directus/directus/issues/11956