### PR TITLE
Verifying by `verification_uri` field variations on Device Authorization Flow.

### DIFF
--- a/lib/device_flow_handle.js
+++ b/lib/device_flow_handle.js
@@ -17,7 +17,9 @@ class DeviceFlowHandle {
   #maxAge;
   #response;
   constructor({ client, exchangeBody, clientAssertionPayload, response, maxAge, DPoP }) {
-    ['verification_uri', 'user_code', 'device_code'].forEach((prop) => {
+    const verificationUriField = response['verification_url'] ? 'verification_url' : 'verification_uri';
+
+    [verificationUriField, 'user_code', 'device_code', 'expires_in'].forEach((prop) => {
       if (typeof response[prop] !== 'string' || !response[prop]) {
         throw new RPError(
           `expected ${prop} string to be returned by Device Authorization Response, got %j`,
@@ -26,7 +28,7 @@ class DeviceFlowHandle {
       }
     });
 
-    if (!Number.isSafeInteger(response.expires_in)) {
+    if (!Number.isSafeInteger(Number(response.expires_in))) {
       throw new RPError(
         'expected expires_in number to be returned by Device Authorization Response, got %j',
         response.expires_in,

--- a/lib/device_flow_handle.js
+++ b/lib/device_flow_handle.js
@@ -19,7 +19,7 @@ class DeviceFlowHandle {
   constructor({ client, exchangeBody, clientAssertionPayload, response, maxAge, DPoP }) {
     const verificationUriField = response['verification_url'] ? 'verification_url' : 'verification_uri';
 
-    [verificationUriField, 'user_code', 'device_code', 'expires_in'].forEach((prop) => {
+    [verificationUriField, 'user_code', 'device_code'].forEach((prop) => {
       if (typeof response[prop] !== 'string' || !response[prop]) {
         throw new RPError(
           `expected ${prop} string to be returned by Device Authorization Response, got %j`,

--- a/lib/device_flow_handle.js
+++ b/lib/device_flow_handle.js
@@ -17,9 +17,9 @@ class DeviceFlowHandle {
   #maxAge;
   #response;
   constructor({ client, exchangeBody, clientAssertionPayload, response, maxAge, DPoP }) {
-    const verificationUriField = response['verification_url'] ? 'verification_url' : 'verification_uri';
+    if(response['verification_url']) response['verification_uri'] = response['verification_url'];
 
-    [verificationUriField, 'user_code', 'device_code'].forEach((prop) => {
+    ['verification_uri', 'user_code', 'device_code'].forEach((prop) => {
       if (typeof response[prop] !== 'string' || !response[prop]) {
         throw new RPError(
           `expected ${prop} string to be returned by Device Authorization Response, got %j`,


### PR DESCRIPTION
I'm working with Azure OIDC and building the Device Authorization flow and was receiving this error: 
<img width="995" alt="error-1" src="https://user-images.githubusercontent.com/29799778/157643753-6d6cf39a-5043-4f9e-b3bb-5b3107513366.png">
 
I did decide to do a deep verification what's happening and I did realize that Azure returns `verification_url` instead `verification_uri`:
<img width="1104" alt="print2" src="https://user-images.githubusercontent.com/29799778/157644064-8acb5114-04e7-4012-adc2-3fe9eaea5d3d.png">

So, I did a verification before, regarding the field name and another fix on `expires_in` field verification.
