### PR TITLE
Add types for error constructors

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,6 +8,7 @@ import * as http2 from 'http2';
 import { URL } from 'url';
 import * as jose from 'jose';
 import * as crypto from 'crypto';
+import { format } from 'util';
 
 export type HttpOptions = Partial<
   Pick<
@@ -572,6 +573,18 @@ export namespace errors {
     scope?: string;
     session_state?: string;
     response?: { body?: UnknownObject | Buffer } & http.IncomingMessage;
+
+    constructor(
+      params: {
+        error: string;
+        error_description?: string;
+        error_uri?: string;
+        state?: string;
+        scope?: string;
+        session_state?: string;
+      },
+      response?: { body?: UnknownObject | Buffer } & http.IncomingMessage,
+    );
   }
 
   class RPError extends Error {
@@ -586,6 +599,14 @@ export namespace errors {
     exp?: number;
     iat?: number;
     auth_time?: number;
+
+    constructor(...args: Parameters<typeof format>);
+    constructor(options: {
+      message?: string;
+      printf?: Parameters<typeof format>;
+      response?: { body?: UnknownObject | Buffer } & http.IncomingMessage;
+      [key: string]: unknown;
+    });
   }
 }
 


### PR DESCRIPTION
I was recently writing some tests for handling errors from `openid-client` and while attempting to instantiate one of the errors, I noticed that the constructor types don't match the implementation.

Since [the types don't explicitly declare a `constructor`](https://github.com/panva/node-openid-client/blob/3adf1a47b5267f7ce20a7c0c29e7207c0ddf34ca/types/index.d.ts#L567-L589), they inherit they inherit it from `Error`, which doesn't match [their overloaded constructors](https://github.com/panva/node-openid-client/blob/3adf1a47b5267f7ce20a7c0c29e7207c0ddf34ca/lib/errors.js#L4).

So, I tried adding what I think are roughly the correct constructor types for the `OPError` and `RPError` classes. I saw that there is a `openid-client-tests.ts` file, so let me know if there's anything additional I should add there as well. Or, feel free to push any additional updates that you see fit to this branch.

Thanks!