### PR TITLE
fix: prevent redefinition of claims within tokenset

### DIFF
--- a/lib/token_set.js
+++ b/lib/token_set.js
@@ -3,6 +3,11 @@ const now = require('./helpers/unix_timestamp');
 
 class TokenSet {
   constructor(values) {
+    if (values && 'claims' in values) {
+      values['_claims'] = values.claims;
+      delete values.claims;
+    }
+
     Object.assign(this, values);
   }
 

--- a/test/tokenset/tokenset.test.js
+++ b/test/tokenset/tokenset.test.js
@@ -38,6 +38,27 @@ describe('TokenSet', function () {
     expect(ts.claims()).to.eql({ sub: '1234567890', name: 'John Doe', admin: true });
   });
 
+  it('#claims does not throw when values contains claims key', function () {
+    const ts = new TokenSet({
+      claims: "foo",
+      id_token:
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ',
+    });
+
+    expect(ts.claims()).not.to.throw;
+  });
+
+  it('#claims is prefixed with an underscore if passed as values', function () {
+    const ts = new TokenSet({
+      claims: "foo",
+      id_token:
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ',
+    });
+
+    expect(ts.claims).not.to.eql('foo');
+    expect(ts._claims).to.eql('foo');
+  });
+
   it('#claims throws if no id_token is present', function () {
     const ts = new TokenSet({});
 


### PR DESCRIPTION
Fixes a problem in which if `values` contained the property `claims`, it would replace the claims function. 

Discovered when trying to call `claims()` on `next-auth` via [this line](https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/core/lib/oauth/callback.ts#L133).

## Checklist
✅ I've added tests to replicate the behaviour automatically