### PR TITLE
fix at_hash validation for servers that provide null at_hash at refresh

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -839,7 +839,7 @@ class BaseClient {
       });
     }
 
-    if (tokenSet.access_token && payload.at_hash !== undefined) {
+    if (tokenSet.access_token && payload.at_hash !== undefined && payload.at_hash !== null) {
       try {
         tokenHash.validate(
           { claim: 'at_hash', source: 'access_token' },


### PR DESCRIPTION
Some openid servers (namely [Authentik](https://goauthentik.io/)) don't provide at_hash on refresh and instead of dropping the key from payload — are setting it to null. 

Example of idToken upon refresh from authentik:

```js
{
  iss: 'https://auth.domain.local/application/o/profiler/',
  sub: '49127....,
  aud: 'c503...,
  exp: 1667651121,
  iat: 1665059121,
  auth_time: 1664880227,
  acr: '[goauthentik.io/providers/oauth2/default](http://goauthentik.io/providers/oauth2/default)',
  c_hash: null,
  nonce: null,
  at_hash: null, // <----- problem
  email: '...',
  email_verified: true,
  name: '...',
  given_name: '...',
  family_name: '',
  preferred_username: '...',
  nickname: '...',
  groups: [ '...']
}
```


This is breaking validation. This commit ads null check

