### PR TITLE
docs: update clock tolerance text

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -658,7 +658,7 @@ client[custom.http_options] = function (url, options) {
 
 #### Customizing clock skew tolerance
 
-It is possible the RP or OP environment has a system clock skew, to set a clock tolerance (in seconds)
+It is possible the RP or OP environment has a system clock skew, which can result in the error "JWT not active yet". To set a clock tolerance (in seconds)
 
 ```js
 import { custom } from 'openid-client';


### PR DESCRIPTION
@panva: When searching the repo for a solution to `JWT not active yet`, the relevant docs did not appear in the search results. #454 did appear, which has a link to the appropriate docs, but this pull request makes the docs a little more discoverable by including the relevant error message.