### PR TITLE
fix(passport): ignore static state and nonce passed to Strategy()

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -840,7 +840,7 @@ Creates a new Strategy
 
 - `options`: `<Object>`
   - `client`: `<Client>` Client instance. The strategy will use it.
-  - `params`: `<Object>` Authorization Request parameters. The strategy will use these.
+  - `params`: `<Object>` Authorization Request parameters. The strategy will use these for every authorization request.
   - `passReqToCallback`: `<boolean>` Boolean specifying whether the verify function should get
     the request object as first argument instead. **Default:** 'false'
   - `usePKCE`: `<boolean>` &vert; `<string>` The PKCE method to use. When 'true' it will resolve based

--- a/docs/README.md
+++ b/docs/README.md
@@ -860,7 +860,7 @@ Creates a new Strategy
 The strategy automatically generates `state` and `nonce` parameters when required. To provide one for a flow where it is optional (for example the `nonce` for the Authorization Code Flow), it can be passed in the optional `options` argument to `passport.authenticate()`:
 
 ```js
-app.post('/auth/openid', function(req, res, next) {
+app.post('/auth/oidc', function(req, res, next) {
   passport.authenticate('oidc', { nonce: crypto.randomBytes(16).toString('base64url') })(req, res, next);
 });
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -857,6 +857,16 @@ Creates a new Strategy
 
 ---
 
+The strategy automatically generates `state` and `nonce` parameters when required. To provide one for a flow where it is optional (for example the `nonce` for the Authorization Code Flow), it can be passed in the optional `options` argument to `passport.authenticate()`:
+
+```js
+app.post('/auth/openid', function(req, res, next) {
+  passport.authenticate('oidc', { nonce: crypto.randomBytes(16).toString('base64url') })(req, res, next);
+});
+```
+
+---
+
 ## generators
 
 <!-- TOC generators START -->

--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -41,6 +41,11 @@ function OpenIDConnectStrategy(
   this._usePKCE = usePKCE;
   this._key = sessionKey || `oidc:${url.parse(this._issuer.issuer).hostname}`;
   this._params = cloneDeep(params);
+
+  // state and nonce should be provided or generated below on each authenticate()
+  delete this._params.state;
+  delete this._params.nonce;
+
   this._extras = cloneDeep(extras);
 
   if (!this._params.response_type) this._params.response_type = resolveResponseType.call(client);


### PR DESCRIPTION
@panva: As discussed, this pull request ignores static `state` and `nonce` values that are passed to the `Strategy()` (a mis-use of the API). Ignoring them here allows them to be dynamically generated on each `authenticate()` for flows that require them.

I also documented how to pass dynamic parameters to `authenticate()` (in a separate commit, daa70a5, in case you aren't interested in this change).

Note that this is a breaking change for users who are mis-using the API in this way if their Authorization Server requires a nonce or state for a flow where the spec does not require it.

Let me know if tests or anything else would be helpful.