### PR TITLE
support audience as comma separated values

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -982,6 +982,25 @@ class BaseClient {
             jwt,
           });
         }
+      } else if (typeof payload.aud === 'string' && payload.aud.indexOf(',') > -1 && payload.aud !== this.client_id) {
+        const audList = payload.aud.split(',').map(aud => aud.trim());
+        if (audList.length > 1 && !payload.azp) {
+          throw new RPError({
+            message: 'missing required JWT property azp',
+            jwt,
+          });
+        }
+
+        if (!audList.includes(this.client_id)) {
+          throw new RPError({
+            printf: [
+              'aud is missing the client_id, expected %s to be included in %j',
+              this.client_id,
+              payload.aud,
+            ],
+            jwt,
+          });
+        }
       } else if (payload.aud !== this.client_id) {
         throw new RPError({
           printf: ['aud mismatch, expected %s, got: %s', this.client_id, payload.aud],


### PR DESCRIPTION
Hello,
I came across an openID implementation that is issuing tokens for multiple audiences but as comma separated values.
Decoded token looks like (see 'aud'):
```
{
  "exp": 1675457424,
  "iat": 1675371024,
  "auth_time": 1675371023,
  "jti": "...",
  "iss": "...",
  "aud": "pos,foo,bar,universal-admin,dayparts,new-portal",
  "sub": "...",
  "typ": "ID",
  "azp": "new-portal",
  "session_state": "...",
  "at_hash": "...",
  "sid": "...",
  "firstName": "New",
  "lastName": "Portal",
  "preferred_username": "...",
  "email": "...",
  "username": "..."
}
```

So the token validation is failing because the `client_id` (new-portal) is not equals to the `token.aud` string in token.
Original `validateJWT()` method is expecting `token.aud` to be an array if you want to validate for multiples audiences.

With this PR `token.aud` can be a string with comma separated values of audiences. There is a check to be backward compatible in case someone is using a `client_id` like literal `pos,foo,bar,universal-admin,dayparts,new-portal` (maybe someone workaround this problem doing that horrible thing...but who knows...). The check is "if client_id and aud matched, no matter if they have comma in the string, we are good. If they do not match and have a comma then try to split and validate"

what do you think?

regards

