### PR TITLE
feat(client): add ability to add custom header in Client.userinfo

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1165,7 +1165,7 @@ class BaseClient {
     return response;
   }
 
-  async userinfo(accessToken, { method = 'GET', via = 'header', tokenType, params, DPoP } = {}) {
+  async userinfo(accessToken, { method = 'GET', via = 'header', tokenType, params, headers, DPoP } = {}) {
     assertIssuerConfiguration(this.issuer, 'userinfo_endpoint');
     const options = {
       tokenType,
@@ -1184,9 +1184,9 @@ class BaseClient {
     const jwt = !!(this.userinfo_signed_response_alg || this.userinfo_encrypted_response_alg);
 
     if (jwt) {
-      options.headers = { Accept: 'application/jwt' };
+      options.headers = {...headers, Accept: 'application/jwt' };
     } else {
-      options.headers = { Accept: 'application/json' };
+      options.headers = {...headers, Accept: 'application/json' };
     }
     const mTLS = !!this.tls_client_certificate_bound_access_tokens;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -338,6 +338,7 @@ declare class BaseClient {
       via?: 'header' | 'body';
       tokenType?: string;
       params?: object;
+      headers?: object;
       DPoP?: DPoPInput;
     },
   ): Promise<UserinfoResponse<TUserInfo, TAddress>>;


### PR DESCRIPTION
Allow specifying custom header in Client.userinfo, for OAuth server that does not accept access token in Authorization header.

This fixes: #581 