### PR TITLE
Allow `default_max_age` to be optional

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -379,7 +379,7 @@ class BaseClient {
       params = await this.validateJARM(decrypted);
     }
 
-    if (this.default_max_age && !checks.max_age) {
+    if (this?.default_max_age && !checks.max_age) {
       checks.max_age = this.default_max_age;
     }
 


### PR DESCRIPTION
The [docs](https://github.com/panva/node-openid-client/blob/main/docs/README.md#new-clientmetadata-jwks-options) say that `default_max_age` is an optional Client constructor property. However, it is used as if it is a required field.
Currently `this.default_max_age` fails if `default_max_age` property is not set so this allows it to not be set.