### PR TITLE
Update passport_strategy.js

### DIFF
--- a/lib/passport_strategy.js
+++ b/lib/passport_strategy.js
@@ -92,9 +92,13 @@ OpenIDConnectStrategy.prototype.authenticate = function authenticate(req, option
      * https://openid.net/specs/openid-connect-core-1_0.html#ThirdPartyInitiatedLogin.
      */
     if (length === 0 || (length === 1 && parameter === 'iss')) {
+      let state = undefined;
+      if(req.session[sessionKey] && req.session[sessionKey]['state']) {
+        state = req.session[sessionKey]['state'];
+      }
       // provide options object with extra authentication parameters
       const params = {
-        state: random(),
+        state: state || random(),
         ...this._params,
         ...options,
       };


### PR DESCRIPTION
Bug fix.
If user opens two login page in same browser then state value is changed and login works from one tab only.