### PR TITLE
feat: rich errors in Issuer discovery / webfinger

### DIFF
--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -129,7 +129,12 @@ module.exports = async function request(options, { accessToken, mTLS = false, DP
       send(req);
     }
 
-    [response] = await Promise.race([once(req, 'response'), once(req, 'timeout')]);
+    [response] = await Promise.race([once(req, 'response'), once(req, 'timeout')]).catch((err) => {
+      throw new RPError({
+        message: 'outgoing request failed',
+        cause: err,
+      });
+    });
 
     // timeout reached
     if (!response) {

--- a/lib/issuer.js
+++ b/lib/issuer.js
@@ -85,22 +85,15 @@ class Issuer {
     const { host } = url.parse(resource);
     const webfingerUrl = `https://${host}/.well-known/webfinger`;
 
-    const response = await request
-      .call(this, {
-        method: 'GET',
-        url: webfingerUrl,
-        responseType: 'json',
-        searchParams: { resource, rel: 'http://openid.net/specs/connect/1.0/issuer' },
-        headers: {
-          Accept: 'application/json',
-        },
-      })
-      .catch((err) => {
-        throw new RPError({
-          message: 'could not load webfinger response',
-          cause: err,
-        });
-      });
+    const response = await request.call(this, {
+      method: 'GET',
+      url: webfingerUrl,
+      responseType: 'json',
+      searchParams: { resource, rel: 'http://openid.net/specs/connect/1.0/issuer' },
+      headers: {
+        Accept: 'application/json',
+      },
+    });
     const body = processResponse(response);
 
     const location =
@@ -148,21 +141,14 @@ class Issuer {
     const parsed = url.parse(uri);
 
     if (parsed.pathname.includes('/.well-known/')) {
-      const response = await request
-        .call(this, {
-          method: 'GET',
-          responseType: 'json',
-          url: uri,
-          headers: {
-            Accept: 'application/json',
-          },
-        })
-        .catch((err) => {
-          throw new RPError({
-            message: 'could not load issuer configuration',
-            cause: err,
-          });
-        });
+      const response = await request.call(this, {
+        method: 'GET',
+        responseType: 'json',
+        url: uri,
+        headers: {
+          Accept: 'application/json',
+        },
+      });
       const body = processResponse(response);
       return new Issuer({
         ...ISSUER_DEFAULTS,
@@ -182,21 +168,14 @@ class Issuer {
 
     const wellKnownUri = url.format({ ...parsed, pathname });
 
-    const response = await request
-      .call(this, {
-        method: 'GET',
-        responseType: 'json',
-        url: wellKnownUri,
-        headers: {
-          Accept: 'application/json',
-        },
-      })
-      .catch((err) => {
-        throw new RPError({
-          message: 'could not load issuer configuration',
-          cause: err,
-        });
-      });
+    const response = await request.call(this, {
+      method: 'GET',
+      responseType: 'json',
+      url: wellKnownUri,
+      headers: {
+        Accept: 'application/json',
+      },
+    });
     const body = processResponse(response);
     return new Issuer({
       ...ISSUER_DEFAULTS,

--- a/lib/issuer.js
+++ b/lib/issuer.js
@@ -85,15 +85,22 @@ class Issuer {
     const { host } = url.parse(resource);
     const webfingerUrl = `https://${host}/.well-known/webfinger`;
 
-    const response = await request.call(this, {
-      method: 'GET',
-      url: webfingerUrl,
-      responseType: 'json',
-      searchParams: { resource, rel: 'http://openid.net/specs/connect/1.0/issuer' },
-      headers: {
-        Accept: 'application/json',
-      },
-    });
+    const response = await request
+      .call(this, {
+        method: 'GET',
+        url: webfingerUrl,
+        responseType: 'json',
+        searchParams: { resource, rel: 'http://openid.net/specs/connect/1.0/issuer' },
+        headers: {
+          Accept: 'application/json',
+        },
+      })
+      .catch((err) => {
+        throw new RPError({
+          message: 'could not load webfinger response',
+          cause: err,
+        });
+      });
     const body = processResponse(response);
 
     const location =
@@ -141,14 +148,21 @@ class Issuer {
     const parsed = url.parse(uri);
 
     if (parsed.pathname.includes('/.well-known/')) {
-      const response = await request.call(this, {
-        method: 'GET',
-        responseType: 'json',
-        url: uri,
-        headers: {
-          Accept: 'application/json',
-        },
-      });
+      const response = await request
+        .call(this, {
+          method: 'GET',
+          responseType: 'json',
+          url: uri,
+          headers: {
+            Accept: 'application/json',
+          },
+        })
+        .catch((err) => {
+          throw new RPError({
+            message: 'could not load issuer configuration',
+            cause: err,
+          });
+        });
       const body = processResponse(response);
       return new Issuer({
         ...ISSUER_DEFAULTS,
@@ -168,14 +182,21 @@ class Issuer {
 
     const wellKnownUri = url.format({ ...parsed, pathname });
 
-    const response = await request.call(this, {
-      method: 'GET',
-      responseType: 'json',
-      url: wellKnownUri,
-      headers: {
-        Accept: 'application/json',
-      },
-    });
+    const response = await request
+      .call(this, {
+        method: 'GET',
+        responseType: 'json',
+        url: wellKnownUri,
+        headers: {
+          Accept: 'application/json',
+        },
+      })
+      .catch((err) => {
+        throw new RPError({
+          message: 'could not load issuer configuration',
+          cause: err,
+        });
+      });
     const body = processResponse(response);
     return new Issuer({
       ...ISSUER_DEFAULTS,


### PR DESCRIPTION
Wrap errors during Issuer requests in `RPError` using `cause` to produce a complete stack trace.

As discussed in #598.