### PR TITLE
fix: handle empty client_secret with basic and post client auth

### DIFF
--- a/lib/helpers/client.js
+++ b/lib/helpers/client.js
@@ -81,7 +81,7 @@ async function authFor(endpoint, { clientAssertionPayload } = {}) {
     case 'none':
       return { form: { client_id: this.client_id } };
     case 'client_secret_post':
-      if (!this.client_secret) {
+      if (!this.client_secret && this.client_secret !== "") {
         throw new TypeError(
           'client_secret_post client authentication method requires a client_secret',
         );
@@ -120,7 +120,7 @@ async function authFor(endpoint, { clientAssertionPayload } = {}) {
       // > Appendix B, and the encoded value is used as the username; the client
       // > password is encoded using the same algorithm and used as the
       // > password.
-      if (!this.client_secret) {
+      if (!this.client_secret && this.client_secret !== "") {
         throw new TypeError(
           'client_secret_basic client authentication method requires a client_secret',
         );

--- a/lib/helpers/client.js
+++ b/lib/helpers/client.js
@@ -81,7 +81,7 @@ async function authFor(endpoint, { clientAssertionPayload } = {}) {
     case 'none':
       return { form: { client_id: this.client_id } };
     case 'client_secret_post':
-      if (!this.client_secret && this.client_secret !== "") {
+      if (!this.client_secret && this.client_secret !== '') {
         throw new TypeError(
           'client_secret_post client authentication method requires a client_secret',
         );
@@ -120,7 +120,7 @@ async function authFor(endpoint, { clientAssertionPayload } = {}) {
       // > Appendix B, and the encoded value is used as the username; the client
       // > password is encoded using the same algorithm and used as the
       // > password.
-      if (!this.client_secret && this.client_secret !== "") {
+      if (!this.client_secret && this.client_secret !== '') {
         throw new TypeError(
           'client_secret_basic client authentication method requires a client_secret',
         );

--- a/lib/helpers/client.js
+++ b/lib/helpers/client.js
@@ -81,7 +81,7 @@ async function authFor(endpoint, { clientAssertionPayload } = {}) {
     case 'none':
       return { form: { client_id: this.client_id } };
     case 'client_secret_post':
-      if (!this.client_secret && this.client_secret !== '') {
+      if (typeof this.client_secret !== 'string') {
         throw new TypeError(
           'client_secret_post client authentication method requires a client_secret',
         );
@@ -120,7 +120,7 @@ async function authFor(endpoint, { clientAssertionPayload } = {}) {
       // > Appendix B, and the encoded value is used as the username; the client
       // > password is encoded using the same algorithm and used as the
       // > password.
-      if (!this.client_secret && this.client_secret !== '') {
+      if (typeof this.client_secret !== 'string') {
         throw new TypeError(
           'client_secret_basic client authentication method requires a client_secret',
         );

--- a/test/client/client_instance.test.js
+++ b/test/client/client_instance.test.js
@@ -2253,6 +2253,18 @@ describe('Client', () => {
           );
         });
       });
+
+      it('allows client_secret to be empty string', async function () {
+        const issuer = new Issuer();
+        const client = new issuer.Client({
+          client_id: 'an:identifier',
+          client_secret: '',
+          token_endpoint_auth_method: 'client_secret_post',
+        });
+        expect(await clientInternal.authFor.call(client, 'token')).to.eql({
+          form: { client_id: 'an:identifier', client_secret: '' },
+        });
+      });
     });
 
     describe('when client_secret_basic', function () {
@@ -2286,6 +2298,14 @@ describe('Client', () => {
           expect(error.message).to.eql(
             'client_secret_basic client authentication method requires a client_secret',
           );
+        });
+      });
+
+      it('allows client_secret to be empty string', async function () {
+        const issuer = new Issuer();
+        const client = new issuer.Client({ client_id: 'an:identifier', client_secret: '' });
+        expect(await clientInternal.authFor.call(client, 'token')).to.eql({
+          headers: { Authorization: 'Basic YW4lM0FpZGVudGlmaWVyOg==' },
         });
       });
     });


### PR DESCRIPTION
Implementation of https://github.com/panva/node-openid-client/issues/609