### PR TITLE
refactor: issuer discovery

### DIFF
--- a/lib/issuer.js
+++ b/lib/issuer.js
@@ -139,7 +139,7 @@ class Issuer {
 
   static async discover(uri) {
 
-    const wellKnownUri = getUri(uri);
+    const wellKnownUri = resolveWellKnownUri(uri);
 
     const response = await request.call(this, {
       method: 'GET',
@@ -174,7 +174,7 @@ class Issuer {
   }
 }
 
-function getUri(uri) {
+function resolveWellKnownUri(uri) {
   const parsed = url.parse(uri);
   if (parsed.pathname.includes('/.well-known/')) {
     return uri;

--- a/lib/issuer.js
+++ b/lib/issuer.js
@@ -138,35 +138,8 @@ class Issuer {
   }
 
   static async discover(uri) {
-    const parsed = url.parse(uri);
 
-    if (parsed.pathname.includes('/.well-known/')) {
-      const response = await request.call(this, {
-        method: 'GET',
-        responseType: 'json',
-        url: uri,
-        headers: {
-          Accept: 'application/json',
-        },
-      });
-      const body = processResponse(response);
-      return new Issuer({
-        ...ISSUER_DEFAULTS,
-        ...body,
-        [AAD_MULTITENANT]: !!AAD_MULTITENANT_DISCOVERY.find((discoveryURL) =>
-          uri.startsWith(discoveryURL),
-        ),
-      });
-    }
-
-    let pathname;
-    if (parsed.pathname.endsWith('/')) {
-      pathname = `${parsed.pathname}.well-known/openid-configuration`;
-    } else {
-      pathname = `${parsed.pathname}/.well-known/openid-configuration`;
-    }
-
-    const wellKnownUri = url.format({ ...parsed, pathname });
+    const wellKnownUri = getUri(uri);
 
     const response = await request.call(this, {
       method: 'GET',
@@ -184,6 +157,21 @@ class Issuer {
         wellKnownUri.startsWith(discoveryURL),
       ),
     });
+
+    function getUri (uri) {
+      const parsed = url.parse(uri)
+      if (parsed.pathname.includes('/.well-known/')) {
+        return uri
+      } else {
+        let pathname
+        if (parsed.pathname.endsWith('/')) {
+          pathname = `${parsed.pathname}.well-known/openid-configuration`
+        } else {
+          pathname = `${parsed.pathname}/.well-known/openid-configuration`
+        }
+        return url.format({ ...parsed, pathname })
+      }
+    };
   }
 
   async reloadJwksUri() {

--- a/lib/issuer.js
+++ b/lib/issuer.js
@@ -158,20 +158,20 @@ class Issuer {
       ),
     });
 
-    function getUri (uri) {
-      const parsed = url.parse(uri)
+    function getUri(uri) {
+      const parsed = url.parse(uri);
       if (parsed.pathname.includes('/.well-known/')) {
-        return uri
+        return uri;
       } else {
-        let pathname
+        let pathname;
         if (parsed.pathname.endsWith('/')) {
-          pathname = `${parsed.pathname}.well-known/openid-configuration`
+          pathname = `${parsed.pathname}.well-known/openid-configuration`;
         } else {
-          pathname = `${parsed.pathname}/.well-known/openid-configuration`
+          pathname = `${parsed.pathname}/.well-known/openid-configuration`;
         }
-        return url.format({ ...parsed, pathname })
+        return url.format({ ...parsed, pathname });
       }
-    };
+    }
   }
 
   async reloadJwksUri() {

--- a/lib/issuer.js
+++ b/lib/issuer.js
@@ -157,21 +157,6 @@ class Issuer {
         wellKnownUri.startsWith(discoveryURL),
       ),
     });
-
-    function getUri(uri) {
-      const parsed = url.parse(uri);
-      if (parsed.pathname.includes('/.well-known/')) {
-        return uri;
-      } else {
-        let pathname;
-        if (parsed.pathname.endsWith('/')) {
-          pathname = `${parsed.pathname}.well-known/openid-configuration`;
-        } else {
-          pathname = `${parsed.pathname}/.well-known/openid-configuration`;
-        }
-        return url.format({ ...parsed, pathname });
-      }
-    }
   }
 
   async reloadJwksUri() {
@@ -186,6 +171,21 @@ class Issuer {
       compact: false,
       sorted: true,
     })}`;
+  }
+}
+
+function getUri(uri) {
+  const parsed = url.parse(uri);
+  if (parsed.pathname.includes('/.well-known/')) {
+    return uri;
+  } else {
+    let pathname;
+    if (parsed.pathname.endsWith('/')) {
+      pathname = `${parsed.pathname}.well-known/openid-configuration`;
+    } else {
+      pathname = `${parsed.pathname}/.well-known/openid-configuration`;
+    }
+    return url.format({ ...parsed, pathname });
   }
 }
 


### PR DESCRIPTION
Just splits uri detection code from a call to discovery endpoint and avoids duplication