### PR TITLE
Add client credentials flow example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,8 +248,7 @@ but upon any other error it will reject. With tokenSet received you can throw aw
 
 ### Client Credentials Grant Flow
 
-Exchanging the client_id and client_secret of your application for an access token, to authenticate
-at a third-party api. Not on behalf of a user. Suitable for Machine-to-Machine authentication.
+Client Credentials flow is for obtaining Access Tokens to use with third party APIs on behalf of your application, rather than an end-user which was the case in previous examples.
 
 **See the [documentation](./docs/README.md#clientgrantbody-extras) for full API details.**
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Client Credentials flow is for obtaining Access Tokens to use with third party A
 **See the [documentation](./docs/README.md#clientgrantbody-extras) for full API details.**
 
 ```js
-const client = new googleIssuer.Client({
+const client = new issuer.Client({
   client_id: 'zELcpfANLqY7Oqas',
   client_secret: 'TQV5U29k1gHibH5bx1layBo0OSAvAbRT3UYW3EWrSYBB5swxjVfWUa1BS8lqzxG/0v9wruMcrGadany3',
 });

--- a/README.md
+++ b/README.md
@@ -246,6 +246,27 @@ This will poll in the defined interval and only resolve with a TokenSet once one
 will handle the defined `authorization_pending` and `slow_down` "soft" errors and continue polling
 but upon any other error it will reject. With tokenSet received you can throw away the handle.
 
+### Client Credentials Grant Flow
+
+Exchanging the client_id and client_secret of your application for an access token, to authenticate
+at a third-party api. Not on behalf of a user. Suitable for Machine-to-Machine authentication.
+
+**See the [documentation][] for full API details.**
+
+```js
+const client = new googleIssuer.Client({
+  client_id: 'zELcpfANLqY7Oqas',
+  client_secret: 'TQV5U29k1gHibH5bx1layBo0OSAvAbRT3UYW3EWrSYBB5swxjVfWUa1BS8lqzxG/0v9wruMcrGadany3',
+  redirect_uris: ['http://localhost:3000/cb'],
+  response_types: ['code']
+});
+
+const tokenSet = await client.grant({
+  audience: 'insert-your-audience',
+  grant_type: 'client_credentials'
+});
+```
+
 ## FAQ
 
 #### Semver?

--- a/README.md
+++ b/README.md
@@ -251,14 +251,12 @@ but upon any other error it will reject. With tokenSet received you can throw aw
 Exchanging the client_id and client_secret of your application for an access token, to authenticate
 at a third-party api. Not on behalf of a user. Suitable for Machine-to-Machine authentication.
 
-**See the [documentation][] for full API details.**
+**See the [documentation](./docs/README.md#clientgrantbody-extras) for full API details.**
 
 ```js
 const client = new googleIssuer.Client({
   client_id: 'zELcpfANLqY7Oqas',
   client_secret: 'TQV5U29k1gHibH5bx1layBo0OSAvAbRT3UYW3EWrSYBB5swxjVfWUa1BS8lqzxG/0v9wruMcrGadany3',
-  redirect_uris: ['http://localhost:3000/cb'],
-  response_types: ['code']
 });
 
 const tokenSet = await client.grant({

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ const client = new googleIssuer.Client({
 });
 
 const tokenSet = await client.grant({
-  audience: 'insert-your-audience',
+  resource: 'urn:example:third-party-api',
   grant_type: 'client_credentials'
 });
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -381,7 +381,8 @@ Performs an arbitrary `grant_type` exchange at the `token_endpoint`.
 
 - `body`: `<Object>`
   - `grant_type`: `<string>`
-  - other properties may be provided depending on the grant in question, like `audience` or `resource` (RFC 8707)
+  - other standard properties like `resource` (RFC 8707), or non-standard properties like `audience` may be provided
+  depending on the OpenID Provider in question.
 - `extras`: `<Object>`
   - `clientAssertionPayload`: `<Object>` extra client assertion payload parameters to be sent as
   part of a client JWT assertion. This is only used when the client's `token_endpoint_auth_method`

--- a/docs/README.md
+++ b/docs/README.md
@@ -382,7 +382,6 @@ Performs an arbitrary `grant_type` exchange at the `token_endpoint`.
 - `body`: `<Object>`
   - `grant_type`: `<string>`
   - other properties may be provided depending on the grant in question
-  depending on the OpenID Provider in question.
 - `extras`: `<Object>`
   - `clientAssertionPayload`: `<Object>` extra client assertion payload parameters to be sent as
   part of a client JWT assertion. This is only used when the client's `token_endpoint_auth_method`

--- a/docs/README.md
+++ b/docs/README.md
@@ -381,7 +381,7 @@ Performs an arbitrary `grant_type` exchange at the `token_endpoint`.
 
 - `body`: `<Object>`
   - `grant_type`: `<string>`
-  - other standard properties like `resource` (RFC 8707), or non-standard properties like `audience` may be provided
+  - other properties may be provided depending on the grant in question
   depending on the OpenID Provider in question.
 - `extras`: `<Object>`
   - `clientAssertionPayload`: `<Object>` extra client assertion payload parameters to be sent as

--- a/docs/README.md
+++ b/docs/README.md
@@ -381,7 +381,7 @@ Performs an arbitrary `grant_type` exchange at the `token_endpoint`.
 
 - `body`: `<Object>`
   - `grant_type`: `<string>`
-  - other properties may be provided depending on the grant in question
+  - other properties may be provided depending on the grant in question, like `audience` or `resource` (RFC 8707)
 - `extras`: `<Object>`
   - `clientAssertionPayload`: `<Object>` extra client assertion payload parameters to be sent as
   part of a client JWT assertion. This is only used when the client's `token_endpoint_auth_method`


### PR DESCRIPTION
As for the headline: names like "client credentials flow" "client credentials grant" and "client credentials grant flow" are flying around. I just went with the latter, idk.