### PR TITLE
feat: expose AAD_MULTITENANT on Issuer

### DIFF
--- a/lib/issuer.js
+++ b/lib/issuer.js
@@ -80,6 +80,10 @@ class Issuer {
     return clone(Object.fromEntries(this.#metadata.entries()));
   }
 
+  static get AAD_MULTITENANT() {
+    return AAD_MULTITENANT;
+  }
+
   static async webfinger(input) {
     const resource = webfingerNormalize(input);
     const { host } = url.parse(resource);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -446,6 +446,7 @@ export class Issuer<TClient extends BaseClient = BaseClient> {
 
   metadata: IssuerMetadata;
   [custom.http_options]: CustomHttpOptionsProvider;
+  static AAD_MULTITENANT: symbol;
   static discover(issuer: string): Promise<Issuer<BaseClient>>;
   static webfinger(input: string): Promise<Issuer<BaseClient>>;
   static [custom.http_options]: CustomHttpOptionsProvider;


### PR DESCRIPTION
Expose the AAD_MULTITENANT on the Issuer class as a static property. This allows creating instances of Issuer by calling the constructor and supplying the metadata object directly instead of needing to execute `await Issuer.discover(...)`.