### PR TITLE
refactor: avoid use of prototype attributes in keystore queries

### DIFF
--- a/lib/helpers/issuer.js
+++ b/lib/helpers/issuer.js
@@ -75,6 +75,7 @@ async function queryKeyStore({ kid, kty, alg, use }, { allowMulti = false } = {}
     ignoreUnknown: true,
     unorderedArrays: true,
     unorderedSets: true,
+    respectType: false,
   });
 
   // refresh keystore on every unknown key but also only upto once every minute


### PR DESCRIPTION
When this library is run under environments which prohibit use of the deprecated `__proto__` getter/setter, it may cause a crash due to reading from the __proto__ property. An example scenario is when the `--disable-proto=throw` flag is used for NodeJS.

To disable consideration of the `prototype`, `__proto__`, and `constructor` fields fields when hashing, the `respectType` flag can be toggled off. This is not a problem for this library, as we are querying only for the existence of a object created via an object literal, which will have these properties all the same anyway.