### PR TITLE
Bumped lru cache to version 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ npm-shrinkwrap.json
 
 # TS test
 types/*.js
+
+
+# Editors
+.idea

--- a/lib/helpers/issuer.js
+++ b/lib/helpers/issuer.js
@@ -13,7 +13,7 @@ const inFlight = new WeakMap();
 const caches = new WeakMap();
 const lrus = (ctx) => {
   if (!caches.has(ctx)) {
-    caches.set(ctx, new LRU({ max: 100 }));
+    caches.set(ctx, new LRU.LRUCache({ max: 100 }));
   }
   return caches.get(ctx);
 };
@@ -28,7 +28,7 @@ async function getKeyStore(reload = false) {
     if (inFlight.has(this)) {
       return inFlight.get(this);
     }
-    cache.reset();
+    cache.clear();
     inFlight.set(
       this,
       (async () => {

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -59,7 +59,7 @@ function send(req, body, contentType) {
   req.end();
 }
 
-const nonces = new LRU({ max: 100 });
+const nonces = new LRU.LRUCache({ max: 100 });
 
 module.exports = async function request(options, { accessToken, mTLS = false, DPoP } = {}) {
   let url;

--- a/lib/issuer.js
+++ b/lib/issuer.js
@@ -127,7 +127,7 @@ class Issuer {
     const issuer = await this.discover(expectedIssuer);
 
     if (issuer.issuer !== expectedIssuer) {
-      registry.del(issuer.issuer);
+      registry.delete(issuer.issuer);
       throw new RPError(
         'discovered issuer mismatch, expected %s, got: %s',
         expectedIssuer,

--- a/lib/issuer_registry.js
+++ b/lib/issuer_registry.js
@@ -1,3 +1,3 @@
 const LRU = require('lru-cache');
 
-module.exports = new LRU({ max: 100 });
+module.exports = new LRU.LRUCache({ max: 100 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "jose": "^4.15.5",
-        "lru-cache": "^6.0.0",
+        "lru-cache": "^10.2.0",
         "object-hash": "^2.2.0",
         "oidc-token-hash": "^5.0.3"
       },
@@ -799,14 +799,11 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
       "engines": {
-        "node": ">=10"
+        "node": "14 || >=16.14"
       }
     },
     "node_modules/methods": {
@@ -1273,11 +1270,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "jose": "^4.15.5",
-    "lru-cache": "^6.0.0",
+    "lru-cache": "^10.2.0",
     "object-hash": "^2.2.0",
     "oidc-token-hash": "^5.0.3"
   },

--- a/test/issuer/discover_webfinger.test.js
+++ b/test/issuer/discover_webfinger.test.js
@@ -127,7 +127,7 @@ describe('Issuer#webfinger()', () => {
   });
 
   it('validates the discovered issuer is the same as from webfinger', function () {
-    Registry.reset();
+    Registry.clear();
     const webfinger = nock('https://op.example.com')
       .get('/.well-known/webfinger')
       .query(function (query) {

--- a/test/issuer/issuer_instance.test.js
+++ b/test/issuer/issuer_instance.test.js
@@ -44,7 +44,7 @@ describe('Issuer', () => {
 
     after(nock.cleanAll);
     afterEach(function () {
-      if (LRU.prototype.get.restore) LRU.prototype.get.restore();
+      if (LRU.LRUCache.prototype.get.restore) LRU.LRUCache.prototype.get.restore();
     });
 
     it('does not refetch immidiately', function () {
@@ -69,7 +69,7 @@ describe('Issuer', () => {
     });
 
     it('asks to fetch if the keystore is stale and new key definition is requested', function () {
-      sinon.stub(LRU.prototype, 'get').returns(undefined);
+      sinon.stub(LRU.LRUCache.prototype, 'get').returns(undefined);
       return issuerInternal.queryKeyStore
         .call(this.issuer, { use: 'sig', alg: 'RS256', kid: 'yeah' })
         .then(fail, () => {
@@ -94,7 +94,7 @@ describe('Issuer', () => {
     });
 
     it('requires a kid is provided in definition if more keys are in the storage', function () {
-      sinon.stub(LRU.prototype, 'get').returns(undefined);
+      sinon.stub(LRU.LRUCache.prototype, 'get').returns(undefined);
       return this.keystore.generate('RSA').then(() => {
         nock('https://op.example.com').get('/certs').reply(200, this.keystore.toJWKS());
 
@@ -110,7 +110,7 @@ describe('Issuer', () => {
     });
 
     it('multiple keys can match the JWT header', function () {
-      sinon.stub(LRU.prototype, 'get').returns(undefined);
+      sinon.stub(LRU.LRUCache.prototype, 'get').returns(undefined);
       const { kid } = this.keystore.get({ kty: 'RSA' });
       return this.keystore.generate('RSA', undefined, { kid }).then(() => {
         nock('https://op.example.com').get('/certs').reply(200, this.keystore.toJWKS());


### PR DESCRIPTION
This should also resolve the issue we have with the different lru-cache dependencies:

https://github.com/ether/etherpad-lite/issues/6330

All tests are passing