### PR TITLE
feat: add resetHttpOptionsDefaults for unsetting defaults

### DIFF
--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -14,7 +14,15 @@ const pick = require('./pick');
 const { deep: defaultsDeep } = require('./defaults');
 const { HTTP_OPTIONS } = require('./consts');
 
-let DEFAULT_HTTP_OPTIONS;
+const DEFAULT_HTTP_OPTIONS = {
+  headers: {
+    'User-Agent': `${pkg.name}/${pkg.version} (${pkg.homepage})`,
+    'Accept-Encoding': 'identity',
+  },
+  timeout: 3500,
+};
+
+let storedHttpOption;
 const NQCHAR = /^[\x21\x23-\x5B\x5D-\x7E]+$/;
 
 const allowed = [
@@ -31,20 +39,18 @@ const allowed = [
 ];
 
 const setDefaults = (props, options) => {
-  DEFAULT_HTTP_OPTIONS = defaultsDeep(
+  storedHttpOption = defaultsDeep(
     {},
     props.length ? pick(options, ...props) : options,
-    DEFAULT_HTTP_OPTIONS,
+    storedHttpOption,
   );
 };
 
-setDefaults([], {
-  headers: {
-    'User-Agent': `${pkg.name}/${pkg.version} (${pkg.homepage})`,
-    'Accept-Encoding': 'identity',
-  },
-  timeout: 3500,
-});
+const resetDefaults = () => {
+  storedHttpOption = defaultsDeep({}, DEFAULT_HTTP_OPTIONS);
+};
+
+resetDefaults();
 
 function send(req, body, contentType) {
   if (contentType) {
@@ -90,11 +96,11 @@ module.exports = async function request(options, { accessToken, mTLS = false, DP
   let userOptions;
   if (optsFn) {
     userOptions = pick(
-      optsFn.call(this, url, defaultsDeep({}, opts, DEFAULT_HTTP_OPTIONS)),
+      optsFn.call(this, url, defaultsDeep({}, opts, storedHttpOption)),
       ...allowed,
     );
   }
-  opts = defaultsDeep({}, userOptions, opts, DEFAULT_HTTP_OPTIONS);
+  opts = defaultsDeep({}, userOptions, opts, storedHttpOption);
 
   if (mTLS && !opts.pfx && !(opts.key && opts.cert)) {
     throw new TypeError('mutual-TLS certificate and key not set');
@@ -198,3 +204,4 @@ module.exports = async function request(options, { accessToken, mTLS = false, DP
 };
 
 module.exports.setDefaults = setDefaults.bind(undefined, allowed);
+module.exports.resetDefaults = resetDefaults.bind(undefined);

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ const Strategy = require('./passport_strategy');
 const TokenSet = require('./token_set');
 const { CLOCK_TOLERANCE, HTTP_OPTIONS } = require('./helpers/consts');
 const generators = require('./helpers/generators');
-const { setDefaults } = require('./helpers/request');
+const { setDefaults, resetDefaults } = require('./helpers/request');
 
 module.exports = {
   Issuer,
@@ -16,6 +16,7 @@ module.exports = {
   },
   custom: {
     setHttpOptionsDefaults: setDefaults,
+    resetHttpOptionsDefaults: resetDefaults,
     http_options: HTTP_OPTIONS,
     clock_tolerance: CLOCK_TOLERANCE,
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,6 +39,7 @@ interface UnknownObject {
 
 export const custom: {
   setHttpOptionsDefaults(params: HttpOptions): undefined;
+  resetHttpOptionsDefaults(): undefined;
   readonly http_options: unique symbol;
   readonly clock_tolerance: unique symbol;
 };


### PR DESCRIPTION
Problem: Whenever `custom.setHttpOptionsDefaults` is called to set headers, there are no available method to remove/unset any of the added headers. This becomes problematic on the event that multiple Client instances need to be created, where the other doesn't need the preconfigured headers.

Currently, the only means to unset headers will be to override them is to call `custom.setHttpOptionsDefaults`, and set the same header key with a null value.

Proposal is to add a resetHttpOptionsDefaults method which unsets everything to the defaults, so that there is no need to unset any value explicitly.

Pseudo-code on usage:
```javascript
custom.setHttpOptionsDefaults({
  headers: {
    Origin: 'some-origin', // required by microsoft provider
  }
});
const msclient = new issuer.Client(config);
// some code to retrieve refreshToken
const tokens = await msclient.refresh(credential.refreshToken); // uses header while performing request

// unless this is reset, all requests will include the preconfigured header
custom.resetHttpOptionsDefaults();

const anotherclient = new issuer.Client(anotherConfig);
```