### PR TITLE
fix: in case there is a port number other than 80 or 443

### DIFF
--- a/src/passport.ts
+++ b/src/passport.ts
@@ -385,7 +385,17 @@ export class Strategy implements passport.Strategy {
    *   callbackURL was specified in the Strategy constructor
    */
   currentUrl(req: express.Request): URL {
-    return new URL(`${req.protocol}://${req.host}${req.url}`)
+    const DEFAULT_PORTS = [80, 443, 0];
+    let port = req.port || '0';
+    let portNumber = parseInt(port, 10);
+    if(portNumber === 0) {
+      const host = req.headers.host;
+      const portFromHost = host.split(':').pop();
+      portNumber = parseInt(portFromHost, 10) || 0;
+    }
+    port = DEFAULT_PORTS.includes(portNumber) ? '' : `:${portNumber}`;
+    const urlString = `${req.protocol}://${req.host}${port}${req.url}`;
+    return new URL(urlString);
   }
 
   authenticate<


### PR DESCRIPTION
```javascript
const strategy = new Strategy({
  config: myConfig, scope: myScope,
  callbackURL: 'https://localhost:8080/callback',
}, myVerifyFunc);

// serializeUser, deserializeUser, etc...

passport.use('my-strategy', strategy);
```

When the callback request reach to the callback URL, it says:
```shell
CSIAQ0167E The redirection URI that is provided in the request [https://localhost/callback] is either invalid, or does not meet the matching criteria for the registered redirection URI.
```

Apparently the port number is missing...